### PR TITLE
use a compatible icu_properties with turbopuffer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,10 +60,10 @@ name = "alyze"
 version = "0.1.0"
 dependencies = [
  "criterion",
- "icu_properties",
  "itertools 0.14.0",
  "parquet",
  "tempfile",
+ "tpuf_icu_properties_211",
  "ureq",
 ]
 
@@ -592,67 +592,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
  "cc",
-]
-
-[[package]]
-name = "icu_collections"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
-dependencies = [
- "displaydoc",
- "potential_utf",
- "yoke",
- "zerofrom",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locale_core"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
-dependencies = [
- "displaydoc",
- "litemap",
- "tinystr",
- "writeable",
- "zerovec",
-]
-
-[[package]]
-name = "icu_properties"
-version = "2.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
-dependencies = [
- "icu_collections",
- "icu_locale_core",
- "icu_properties_data",
- "icu_provider",
- "zerotrie",
- "zerovec",
-]
-
-[[package]]
-name = "icu_properties_data"
-version = "2.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
-
-[[package]]
-name = "icu_provider"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
-dependencies = [
- "displaydoc",
- "icu_locale_core",
- "writeable",
- "yoke",
- "zerofrom",
- "zerotrie",
- "zerovec",
 ]
 
 [[package]]
@@ -1304,6 +1243,67 @@ checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
 dependencies = [
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "tpuf_icu_collections_211"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d222a8d90299a48d0a9a247a3eef0d92eb0e7c6fe2988800448c035066ecf90b"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "tpuf_icu_locale_core_211"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed07e77de2e982b19f8c3ef48d45cfe9300ae7f8b5f03f01ca03c6031881eb02"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "tpuf_icu_properties_211"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c455fcb9714106a167df19d9fc495799d9fe154c01bdf1e60ef53e3b33459ce4"
+dependencies = [
+ "tpuf_icu_collections_211",
+ "tpuf_icu_locale_core_211",
+ "tpuf_icu_properties_data_211",
+ "tpuf_icu_provider_211",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "tpuf_icu_properties_data_211"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63d9d9272c84599f796b52595ca71045d8a97e377e949a26405f7760dc75c554"
+
+[[package]]
+name = "tpuf_icu_provider_211"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3603ac1b818b23d55b832c277df9ff75bd0cdbb2bde06b6f6d4e54cc04d0e402"
+dependencies = [
+ "displaydoc",
+ "tpuf_icu_locale_core_211",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,7 +57,7 @@ dependencies = [
 
 [[package]]
 name = "alyze"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "criterion",
  "itertools 0.14.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alyze"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 rust-version = "1.85"
 description = "High-performance text analysis for full-text search"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["text-processing", "internationalization"]
 exclude = ["testdata/", "benches/"]
 
 [dependencies]
-icu_properties = "2.1.2"
+tpuf_icu_properties_211 = "7"
 
 [dev-dependencies]
 criterion = "0.8.2"

--- a/src/uax29/sentence/properties.rs
+++ b/src/uax29/sentence/properties.rs
@@ -1,4 +1,4 @@
-use icu_properties::{CodePointMapData, CodePointMapDataBorrowed, props::SentenceBreak};
+use tpuf_icu_properties_211::{CodePointMapData, CodePointMapDataBorrowed, props::SentenceBreak};
 
 use crate::uax29::break_property_enum;
 

--- a/src/uax29/word/properties.rs
+++ b/src/uax29/word/properties.rs
@@ -1,4 +1,4 @@
-use icu_properties::{
+use tpuf_icu_properties_211::{
     CodePointMapData, CodePointMapDataBorrowed, CodePointSetData, CodePointSetDataBorrowed,
     props::{ExtendedPictographic, WordBreak},
 };


### PR DESCRIPTION
Use turbopuffer's pinned icu_properties 2.1.1 (for Unicode v17) to ensure compatibility, this should make it possible to import `alyze` into the main repo without any conflicts.