### PR TITLE
add tpuf-vendored feature to switch icu_properties source

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,6 +60,7 @@ name = "alyze"
 version = "0.1.1"
 dependencies = [
  "criterion",
+ "icu_properties",
  "itertools 0.14.0",
  "parquet",
  "tempfile",
@@ -592,6 +593,67 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "icu_collections"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+
+[[package]]
+name = "icu_provider"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,14 @@ keywords = ["tokenizer", "unicode", "segmentation", "analysis", "nlp"]
 categories = ["text-processing", "internationalization"]
 exclude = ["testdata/", "benches/"]
 
+[features]
+default = ["icu-properties"]
+icu-properties = ["dep:icu_properties"]
+tpuf-vendored = ["dep:tpuf_icu_properties_211"]
+
 [dependencies]
-tpuf_icu_properties_211 = "7"
+icu_properties = { version = "2.1.2", optional = true }
+tpuf_icu_properties_211 = { version = "7", optional = true }
 
 [dev-dependencies]
 criterion = "0.8.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,4 +8,10 @@
 //! assert_eq!(breaks, vec![0, 5, 6, 7, 12, 13]);
 //! ```
 
+#[cfg(not(feature = "tpuf-vendored"))]
+extern crate icu_properties as icu;
+
+#[cfg(feature = "tpuf-vendored")]
+extern crate tpuf_icu_properties_211 as icu;
+
 pub mod uax29;

--- a/src/uax29/sentence/properties.rs
+++ b/src/uax29/sentence/properties.rs
@@ -1,4 +1,4 @@
-use tpuf_icu_properties_211::{CodePointMapData, CodePointMapDataBorrowed, props::SentenceBreak};
+use crate::icu::{CodePointMapData, CodePointMapDataBorrowed, props::SentenceBreak};
 
 use crate::uax29::break_property_enum;
 

--- a/src/uax29/word/properties.rs
+++ b/src/uax29/word/properties.rs
@@ -1,4 +1,4 @@
-use tpuf_icu_properties_211::{
+use crate::icu::{
     CodePointMapData, CodePointMapDataBorrowed, CodePointSetData, CodePointSetDataBorrowed,
     props::{ExtendedPictographic, WordBreak},
 };


### PR DESCRIPTION
## Summary
- Adds a `tpuf-vendored` feature that swaps the `icu_properties` dependency for `tpuf_icu_properties_211 = 7`.
- Default features keep `icu_properties = 2.1.2`. Both deps are optional and mutually exclusive, so turbopuffer can consume alyze with `default-features = false, features = ["tpuf-vendored"]` and avoid pulling in a second copy of `icu_properties`.

## Test plan
- [x] `cargo test --lib` (default features)
- [x] `cargo test --lib --no-default-features --features tpuf-vendored`