### PR TITLE
Add Hebrew single-quote word break coverage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,7 +57,7 @@ dependencies = [
 
 [[package]]
 name = "alyze"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "criterion",
  "itertools 0.14.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alyze"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 rust-version = "1.85"
 description = "High-performance text analysis for full-text search"

--- a/src/uax29/word/mod.rs
+++ b/src/uax29/word/mod.rs
@@ -220,6 +220,17 @@ mod tests {
         assert_breaks("can'", vec![0, 3, 4]);
         assert_breaks("can' hi", vec![0, 3, 4, 5, 7]);
 
+        // WB7a and WB6/WB7 with Hebrew_Letter and Single_Quote.
+        assert_breaks("א'", vec![0, "א'".len()]);
+        assert_breaks("א'א", vec![0, "א'א".len()]);
+        assert_breaks("א'\u{2060}א", vec![0, "א'\u{2060}א".len()]);
+        assert_breaks("א'a", vec![0, "א'a".len()]);
+        assert_breaks("הצ'קרות", vec![0, "הצ'קרות".len()]);
+        assert_breaks(
+            "לייף אנרג'י",
+            vec![0, "לייף".len(), "לייף ".len(), "לייף אנרג'י".len()],
+        );
+
         // WB3c: ZWJ × Extended_Pictographic (emoji ZWJ sequences)
         assert_breaks("👨\u{200D}👩", vec![0, 11]);
         assert_breaks("👨👩", vec![0, 4, 8]);

--- a/src/uax29/word/transitions.rs
+++ b/src/uax29/word/transitions.rs
@@ -4,7 +4,7 @@ use crate::uax29::{Action, state_enum, word::properties::WordBreakProperty};
 // an implementation detail of UAX#29, not documented in the spec.
 state_enum! {
     StartOfText, Any, CR, ALetter, Numeric, HLetter, Katakana,
-    ExtendNumLet, WSegSpace, AHLetterMid, Newline, RIOdd, NumericMid, HLetterDQ,
+    ExtendNumLet, WSegSpace, AHLetterMid, Newline, RIOdd, NumericMid, HLetterDQ, HLetterSQ,
 }
 
 impl State {
@@ -22,7 +22,8 @@ impl State {
             | State::ExtendNumLet
             | State::WSegSpace
             | State::RIOdd
-            | State::Newline => false,
+            | State::Newline
+            | State::HLetterSQ => false,
         }
     }
 }
@@ -52,6 +53,7 @@ pub(crate) const TABLE: [Row; State::NUM_VARIANTS] = [
     ri_odd_transitions(),
     numeric_mid_transitions(),
     hletter_dq_transitions(),
+    hletter_sq_transitions(),
 ];
 
 const fn default_all_break() -> Row {
@@ -173,10 +175,9 @@ const fn hletter_transitions() -> Row {
     // WB6: AHLetter	×	(MidLetter | MidNumLetQ) AHLetter
     row[WordBreakProperty::MidLetter as usize] = nb(State::AHLetterMid);
     row[WordBreakProperty::MidNumLet as usize] = nb(State::AHLetterMid);
-    row[WordBreakProperty::SingleQuote as usize] = nb(State::AHLetterMid);
 
     // WB7a: Hebrew_Letter × Single_Quote
-    row[WordBreakProperty::SingleQuote as usize] = nb(State::Any);
+    row[WordBreakProperty::SingleQuote as usize] = nb(State::HLetterSQ);
 
     // WB7b: Hebrew_Letter × Double_Quote Hebrew_Letter
     row[WordBreakProperty::DoubleQuote as usize] = nb(State::HLetterDQ);
@@ -270,6 +271,14 @@ const fn numeric_mid_transitions() -> Row {
 // Hebrew_Letter Double_Quote × Hebrew_Letter
 const fn hletter_dq_transitions() -> Row {
     let mut row = default_all_deferred();
+    row[WordBreakProperty::HebrewLetter as usize] = nb(State::HLetter);
+    row
+}
+
+// Helper state for handling WB7a plus WB7 after Hebrew_Letter × Single_Quote.
+const fn hletter_sq_transitions() -> Row {
+    let mut row = default_all_break();
+    row[WordBreakProperty::ALetter as usize] = nb(State::ALetter);
     row[WordBreakProperty::HebrewLetter as usize] = nb(State::HLetter);
     row
 }


### PR DESCRIPTION
## Summary
- Add DFA support for Hebrew letter + single quote sequences so WB7a and WB7 stay attached across apostrophes.
- Add unit tests for Hebrew apostrophe cases, including transparency through `U+2060 WORD JOINER` and a mixed Hebrew/Latin case.

## Testing
- Unit tests added for the new Hebrew apostrophe scenarios.
- `cargo test -q` passed, including the existing `WordBreakTest` coverage.
- `cargo fmt --check` passed.