### PR TITLE
Add `TokenProperties` to returned per-token boundaries

### DIFF
--- a/benches/wikipedia.rs
+++ b/benches/wikipedia.rs
@@ -37,6 +37,25 @@ pub fn wikipedia_benchmark(c: &mut Criterion) {
         })
     });
 
+    // When `props` is unused, LLVM will optimize it away (which is amazing!), but we also want
+    // to benchmark the cost of computing and using this word-like property.
+    group.bench_function("word break + word_like", |b| {
+        b.iter(|| {
+            let mut count = 0;
+            let mut word_like = 0;
+            for text in &texts {
+                uax29::word::tokenize(text, uax29::word::Options::default(), |_, props| {
+                    count += 1;
+                    if props.is_word_like() {
+                        word_like += 1;
+                    }
+                    true
+                });
+            }
+            std::hint::black_box((&count, &word_like));
+        })
+    });
+
     group.bench_function("sentence break", |b| {
         b.iter(|| {
             let mut count = 0;

--- a/benches/wikipedia.rs
+++ b/benches/wikipedia.rs
@@ -28,7 +28,7 @@ pub fn wikipedia_benchmark(c: &mut Criterion) {
         b.iter(|| {
             let mut count = 0;
             for text in &texts {
-                uax29::word::tokenize(text, uax29::word::Options::default(), |_| {
+                uax29::word::tokenize(text, uax29::word::Options::default(), |_, _| {
                     count += 1;
                     true
                 });

--- a/benches/wikipedia.rs
+++ b/benches/wikipedia.rs
@@ -26,25 +26,27 @@ pub fn wikipedia_benchmark(c: &mut Criterion) {
 
     group.bench_function("word break", |b| {
         b.iter(|| {
-            let mut breakpoints = Vec::new();
+            let mut count = 0;
             for text in &texts {
-                uax29::word::tokenize(text, &mut breakpoints, uax29::word::Options::default());
+                uax29::word::tokenize(text, uax29::word::Options::default(), |_| {
+                    count += 1;
+                    true
+                });
             }
-            std::hint::black_box(&breakpoints);
+            std::hint::black_box(&count);
         })
     });
 
     group.bench_function("sentence break", |b| {
         b.iter(|| {
-            let mut breakpoints = Vec::new();
+            let mut count = 0;
             for text in &texts {
-                uax29::sentence::tokenize(
-                    text,
-                    &mut breakpoints,
-                    uax29::sentence::Options::default(),
-                );
+                uax29::sentence::tokenize(text, uax29::sentence::Options::default(), |_| {
+                    count += 1;
+                    true
+                });
             }
-            std::hint::black_box(&breakpoints);
+            std::hint::black_box(&count);
         })
     });
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,10 @@
 //!
 //! ```
 //! let mut breaks = Vec::new();
-//! alyze::uax29::word::tokenize("Hello, world!", &mut breaks, Default::default());
+//! alyze::uax29::word::tokenize("Hello, world!", Default::default(), |bp| {
+//!     breaks.push(bp);
+//!     true // return false to stop tokenization early
+//! });
 //! assert_eq!(breaks, vec![0, 5, 6, 7, 12, 13]);
 //! ```
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
 //!
 //! ```
 //! let mut breaks = Vec::new();
-//! alyze::uax29::word::tokenize("Hello, world!", Default::default(), |bp| {
+//! alyze::uax29::word::tokenize("Hello, world!", Default::default(), |bp, _| {
 //!     breaks.push(bp);
 //!     true // return false to stop tokenization early
 //! });

--- a/src/uax29/sentence/mod.rs
+++ b/src/uax29/sentence/mod.rs
@@ -9,7 +9,7 @@ use transitions::{State, TRANSITION_TABLE, Transition};
 #[non_exhaustive]
 pub struct Options {}
 
-pub fn tokenize(text: &str, breakpoints: &mut Vec<usize>, _options: Options) {
+pub fn tokenize(text: &str, _options: Options, mut on_breakpoint: impl FnMut(usize) -> bool) {
     if text.is_empty() {
         return;
     }
@@ -29,7 +29,9 @@ pub fn tokenize(text: &str, breakpoints: &mut Vec<usize>, _options: Options) {
         match action {
             Action::Break => {
                 state = next_state;
-                breakpoints.push(pos);
+                if !on_breakpoint(pos) {
+                    return;
+                }
                 pos += char_len;
                 continue;
             }
@@ -52,7 +54,9 @@ pub fn tokenize(text: &str, breakpoints: &mut Vec<usize>, _options: Options) {
                 let boundary = deferred_break_pos.take().unwrap();
                 state = next_state;
                 // Don't advance pos — re-examine current char in new state.
-                breakpoints.push(boundary);
+                if !on_breakpoint(boundary) {
+                    return;
+                }
                 continue;
             }
         }
@@ -60,11 +64,13 @@ pub fn tokenize(text: &str, breakpoints: &mut Vec<usize>, _options: Options) {
 
     // Deferred state at EOT — defer failed, confirm break
     if state.is_deferred() {
-        breakpoints.push(deferred_break_pos.take().unwrap());
+        if !on_breakpoint(deferred_break_pos.unwrap()) {
+            return;
+        }
     }
 
     // SB2: Any	÷ eot (break at end of text)
-    breakpoints.push(text.len());
+    _ = on_breakpoint(text.len());
 }
 
 #[cfg(test)]
@@ -76,7 +82,10 @@ mod tests {
     fn test_sentence_break_against_uax29_tests() {
         let (passed, failed) =
             test_against_uax29_break_tests("testdata/SentenceBreakTest.txt", |s, breakpoints| {
-                tokenize(s, breakpoints, Options::default())
+                tokenize(s, Options::default(), |bp| {
+                    breakpoints.push(bp);
+                    true
+                });
             });
         assert_eq!(
             (512, 0),
@@ -91,7 +100,10 @@ mod tests {
     fn tokenizer_sanity() {
         fn assert_breaks(s: &str, expected: Vec<usize>) {
             let mut breakpoints = Vec::new();
-            tokenize(s, &mut breakpoints, Options::default());
+            tokenize(s, Options::default(), |bp| {
+                breakpoints.push(bp);
+                true
+            });
             assert_eq!(breakpoints, expected, "input: {:?}", s);
         }
 

--- a/src/uax29/word/mod.rs
+++ b/src/uax29/word/mod.rs
@@ -3,7 +3,8 @@ pub(crate) mod transitions;
 
 use crate::uax29::Action;
 use properties::{
-    ASCII_WORD_BREAK_PROP, WordBreakProperty, lookup_word_break_property_from_dictionary,
+    ASCII_WORD_BREAK_PROP, WordBreakProperty, is_word_like_strict,
+    lookup_word_break_property_from_dictionary,
 };
 use transitions::{State, TABLE, Transition};
 
@@ -25,6 +26,8 @@ impl TokenProperties {
 
     /// Tokenizer-internal: contribution from a single non-ASCII char.
     pub(crate) const NON_ASCII: Self = Self(Self::NON_ASCII_MASK);
+    /// Tokenizer-internal: contribution from a single word-like char.
+    pub(crate) const WORD_LIKE: Self = Self(Self::WORD_LIKE_MASK);
 
     pub fn is_word_like(&self) -> bool {
         self.0 & Self::WORD_LIKE_MASK != 0
@@ -81,10 +84,17 @@ pub fn tokenize(
             State::ALetter | State::Numeric | State::ExtendNumLet | State::HLetter
         ) {
             let scan_start = pos;
-            while pos < text.len() && bytes[pos] < 0x80 && WORD_CONTINUE[bytes[pos] as usize] {
+            let mut fast_acc: u8 = 0;
+            while pos < text.len() && bytes[pos] < 0x80 {
+                let info = ASCII_BYTE_INFO[bytes[pos] as usize];
+                if info & ASCII_WORD_CONTINUE == 0 {
+                    break;
+                }
+                fast_acc |= info;
                 pos += 1;
             }
             if pos > scan_start {
+                token_props.0 |= fast_acc & !ASCII_WORD_CONTINUE;
                 let last = bytes[pos - 1]; // Safe because we're not in State::StartOfText.
                 state = match last {
                     b'0'..=b'9' => State::Numeric,
@@ -107,16 +117,19 @@ pub fn tokenize(
                 b as char,
                 ASCII_WORD_BREAK_PROP[b as usize],
                 1usize,
-                TokenProperties::default(),
+                TokenProperties(ASCII_BYTE_INFO[b as usize] & !ASCII_WORD_CONTINUE),
             )
         } else {
             let c = text[pos..].chars().next().unwrap();
-            (
-                c,
-                lookup_word_break_property_from_dictionary(c),
-                c.len_utf8(),
-                TokenProperties::NON_ASCII,
-            )
+            let prop = lookup_word_break_property_from_dictionary(c);
+            // Cheap path covers ALetter / HebrewLetter / Numeric. For everything else, fall back
+            // to the strict per-char check (ExtPict / Ideographic / Script / OtherNumber).
+            let mut char_props = TokenProperties::NON_ASCII;
+            char_props |= WORD_BREAK_CONTRIB[prop as usize];
+            if !char_props.is_word_like() && is_word_like_strict(c) {
+                char_props |= TokenProperties::WORD_LIKE;
+            }
+            (c, prop, c.len_utf8(), char_props)
         };
 
         // Each iteration, we consult the transition table to determine the next state
@@ -188,15 +201,33 @@ pub fn tokenize(
     _ = on_breakpoint(text.len(), token_props);
 }
 
-// Lookup table for ASCII characters, which can be processed without the DFA.
-// Specifically, if we see a given ASCII character, can we just immediately skip to the next one?
-const WORD_CONTINUE: [bool; 128] = {
-    let mut t = [false; 128];
+/// Cheap-path `TokenProperties` contribution for each `WordBreakProperty` value. Covers the
+/// signals that fall out of WordBreak alone — letters and digits. Katakana is intentionally
+/// **not** included: its set mixes Katakana letters (word-like) with the prolonged-sound mark
+/// `ー` (Script=Common, not word-like). Those split is resolved via `is_word_like_strict`.
+const WORD_BREAK_CONTRIB: [TokenProperties; WordBreakProperty::NUM_VARIANTS] = {
+    let mut t = [TokenProperties(0); WordBreakProperty::NUM_VARIANTS];
+    t[WordBreakProperty::ALetter as usize] = TokenProperties::WORD_LIKE;
+    t[WordBreakProperty::HebrewLetter as usize] = TokenProperties::WORD_LIKE;
+    t[WordBreakProperty::Numeric as usize] = TokenProperties::WORD_LIKE;
+    t
+};
+
+/// Per-ASCII-byte info for the fast-path scan and the single-char branch.
+/// - Bit 7 (`ASCII_WORD_CONTINUE`): byte is part of a word-like run (`[a-zA-Z0-9_]`).
+/// - Low bits: the byte's `TokenProperties` contribution (currently just `WORD_LIKE_MASK` for
+///   `[a-zA-Z0-9]`, since underscore continues the run but isn't itself word-like).
+const ASCII_WORD_CONTINUE: u8 = 0b1000_0000;
+const ASCII_BYTE_INFO: [u8; 128] = {
+    let mut t = [0u8; 128];
     let mut i = 0u8;
     loop {
         t[i as usize] = match i {
-            b'a'..=b'z' | b'A'..=b'Z' | b'0'..=b'9' | b'_' => true,
-            _ => false,
+            b'a'..=b'z' | b'A'..=b'Z' | b'0'..=b'9' => {
+                ASCII_WORD_CONTINUE | TokenProperties::WORD_LIKE_MASK
+            }
+            b'_' => ASCII_WORD_CONTINUE,
+            _ => 0,
         };
         if i == 127 {
             break;
@@ -205,6 +236,15 @@ const WORD_CONTINUE: [bool; 128] = {
     }
     t
 };
+
+#[unsafe(no_mangle)]
+#[inline(never)]
+pub fn _asm_probe(text: &str, out: &mut Vec<usize>) {
+    tokenize(text, Options::default(), |bp, _| {
+        out.push(bp);
+        true
+    });
+}
 
 #[cfg(test)]
 mod tests {
@@ -331,5 +371,61 @@ mod tests {
         // The sharp case: the breaking char is non-ASCII but starts the *next* token, so "ab"
         // must still report is_ascii=true and "🛑" must report is_ascii=false.
         assert_props("ab🛑", vec![(0, true), (2, true), (6, false)]);
+    }
+
+    fn assert_word_like(s: &str, expected: Vec<(usize, bool)>) {
+        let mut got: Vec<(usize, bool)> = Vec::new();
+        tokenize(s, Options::default(), |bp, props| {
+            got.push((bp, props.is_word_like()));
+            true
+        });
+        assert_eq!(got, expected, "input: {:?}", s);
+    }
+
+    /// ASCII subset of the word-like contract: any token containing an ASCII letter or digit is
+    /// word-like; pure-connector / whitespace / punctuation tokens are not. The leading boundary
+    /// at 0 has no preceding span, so word_like is vacuously false.
+    #[test]
+    fn tokenizer_word_like_ascii_sanity() {
+        // ASCII letters / digits / mixed / contractions.
+        assert_word_like("hello", vec![(0, false), (5, true)]);
+        assert_word_like("123", vec![(0, false), (3, true)]);
+        assert_word_like("abc123", vec![(0, false), (6, true)]);
+        assert_word_like("won't", vec![(0, false), (5, true)]);
+
+        // Connectors only (ExtendNumLet) — `_` is not a letter or digit.
+        assert_word_like("___", vec![(0, false), (3, false)]);
+        // Whitespace only.
+        assert_word_like("   ", vec![(0, false), (3, false)]);
+        // ASCII punctuation: each '!' breaks separately, none word-like.
+        assert_word_like("!!!", vec![(0, false), (1, false), (2, false), (3, false)]);
+    }
+
+    /// Strict cases that need Script / Ideographic / OtherNumber / ExtPict lookups beyond the
+    /// WordBreak property.
+    #[test]
+    fn tokenizer_word_like_strict_sanity() {
+        // Hebrew (HebrewLetter prop)
+        assert_word_like("ש", vec![(0, false), (2, true)]);
+
+        // CJK ideograph: WordBreak=Other, Script=Han.
+        assert_word_like("中", vec![(0, false), (3, true)]);
+        // Ideographic iteration mark: WordBreak=Other, Script=Common, Ideographic=true.
+        assert_word_like("々", vec![(0, false), (3, true)]);
+        // Circled digit: WordBreak=Other, GeneralCategory=OtherNumber.
+        assert_word_like("①", vec![(0, false), (3, true)]);
+        // Devanagari letter: WordBreak=Other, Script=Devanagari.
+        assert_word_like("अ", vec![(0, false), (3, true)]);
+        // Thai letter: WordBreak=Other, Script=Thai.
+        assert_word_like("ก", vec![(0, false), (3, true)]);
+        // Emoji: WordBreak=Other (or ExtPict), Script=Common, ExtendedPictographic=true.
+        assert_word_like("👍", vec![(0, false), (4, true)]);
+
+        // Real Katakana letter: WordBreak=Katakana, Script=Katakana → word-like.
+        assert_word_like("リ", vec![(0, false), (3, true)]);
+        // Katakana-Hiragana extender: WordBreak=Katakana, Script=Common → NOT word-like.
+        // Locks in why we can't just OR `WordBreakProperty::Katakana → WORD_LIKE`; we need to
+        // additionally check the char's Script.
+        assert_word_like("ー", vec![(0, false), (3, false)]);
     }
 }

--- a/src/uax29/word/mod.rs
+++ b/src/uax29/word/mod.rs
@@ -20,19 +20,23 @@ pub struct TokenProperties(u8);
 
 impl TokenProperties {
     const WORD_LIKE_MASK: u8 = 0b0000_0001;
-    // Stored disjunctively: a single non-ASCII char in the span sets this bit.
-    // `is_ascii()` returns true when the bit is unset (vacuously true for the empty span).
     const NON_ASCII_MASK: u8 = 0b0000_0010;
 
-    /// Tokenizer-internal: contribution from a single non-ASCII char.
     pub(crate) const NON_ASCII: Self = Self(Self::NON_ASCII_MASK);
-    /// Tokenizer-internal: contribution from a single word-like char.
     pub(crate) const WORD_LIKE: Self = Self(Self::WORD_LIKE_MASK);
 
+    // A token is "word-like" if it contains any char that is:
+    // - ALetter, HebrewLetter, or Numeric (this is a fast-path from our DFA WordBreakProperty lookup)
+    // - Ideographic or Extended_Pictographic (e.g. CJK chars, emoji)
+    // - Other_Number general category (⑦, ², ¼)
+    // - A character whose Script is something meaningful (e.g. belonging to a real writing system),
+    //   as opposed to Script=Common/Inherited/Unknown (e.g. punctuation, symbols, emoji modifiers).
     pub fn is_word_like(&self) -> bool {
         self.0 & Self::WORD_LIKE_MASK != 0
     }
 
+    // Stored disjunctively: a single non-ASCII char in the span sets this bit.
+    // `is_ascii()` returns true when the bit is unset (vacuously true for the empty span).
     pub fn is_ascii(&self) -> bool {
         self.0 & Self::NON_ASCII_MASK == 0
     }

--- a/src/uax29/word/mod.rs
+++ b/src/uax29/word/mod.rs
@@ -15,7 +15,7 @@ pub struct Options {}
 
 /// For a given span, extracts info from the DFA state to provide useful information upstream, e.g.
 /// whether the span was "word-like", ascii, etc
-#[derive(Copy, Clone, Default)]
+#[derive(Copy, Clone, Default, Debug, Eq, PartialEq)]
 pub struct TokenProperties(u8);
 
 impl TokenProperties {

--- a/src/uax29/word/mod.rs
+++ b/src/uax29/word/mod.rs
@@ -12,10 +12,44 @@ use transitions::{State, TABLE, Transition};
 #[non_exhaustive]
 pub struct Options {}
 
+/// For a given span, extracts info from the DFA state to provide useful information upstream, e.g.
+/// whether the span was "word-like", ascii, etc
+#[derive(Copy, Clone, Default)]
+pub struct TokenProperties(u8);
+
+impl TokenProperties {
+    const WORD_LIKE_MASK: u8 = 0b0000_0001;
+    // Stored disjunctively: a single non-ASCII char in the span sets this bit.
+    // `is_ascii()` returns true when the bit is unset (vacuously true for the empty span).
+    const NON_ASCII_MASK: u8 = 0b0000_0010;
+
+    /// Tokenizer-internal: contribution from a single non-ASCII char.
+    pub(crate) const NON_ASCII: Self = Self(Self::NON_ASCII_MASK);
+
+    pub fn is_word_like(&self) -> bool {
+        self.0 & Self::WORD_LIKE_MASK != 0
+    }
+
+    pub fn is_ascii(&self) -> bool {
+        self.0 & Self::NON_ASCII_MASK == 0
+    }
+}
+
+impl std::ops::BitOrAssign for TokenProperties {
+    #[inline]
+    fn bitor_assign(&mut self, rhs: Self) {
+        self.0 |= rhs.0;
+    }
+}
+
 /// A tokenizer that implements UAX #29 word boundary rules, using a deterministic finite automaton
 /// (DFA) to efficiently determine word boundaries in Unicode text. Includes a number of fast-paths
 /// for common cases, e.g. ASCII.
-pub fn tokenize(text: &str, _options: Options, mut on_breakpoint: impl FnMut(usize) -> bool) {
+pub fn tokenize(
+    text: &str,
+    _options: Options,
+    mut on_breakpoint: impl FnMut(usize, TokenProperties) -> bool,
+) {
     if text.is_empty() {
         return;
     }
@@ -34,6 +68,10 @@ pub fn tokenize(text: &str, _options: Options, mut on_breakpoint: impl FnMut(usi
     // 'a 🛑' -> break (ALetter -> Other)
     // 'a ZWJ 🛑' -> no break (WB4)
     let mut last_was_zwj = false;
+
+    // Maintain properties of the current token, which are reset on each break and can be used by the caller
+    // to more efficiently determine what type of token was just emitted, e.g. whether it's "word-like" or ascii.
+    let mut token_props = TokenProperties::default();
 
     while pos < text.len() {
         // Fast path for ASCII, e.g. skip DFA all together when possible.
@@ -59,15 +97,25 @@ pub fn tokenize(text: &str, _options: Options, mut on_breakpoint: impl FnMut(usi
         }
 
         // Fast path for ASCII, e.g. avoid chars().next(), and lookup word property from table.
+        // `char_props` is this char's contribution to the enclosing token's properties; it's
+        // applied to `token_props` per-arm below, since `Action::Break` treats the breaking char
+        // as the first char of the *next* token (the contribution lands there, not in the token
+        // being emitted).
         let b = bytes[pos];
-        let (c, prop, char_len) = if b < 0x80 {
-            (b as char, ASCII_WORD_BREAK_PROP[b as usize], 1usize)
+        let (c, prop, char_len, char_props) = if b < 0x80 {
+            (
+                b as char,
+                ASCII_WORD_BREAK_PROP[b as usize],
+                1usize,
+                TokenProperties::default(),
+            )
         } else {
             let c = text[pos..].chars().next().unwrap();
             (
                 c,
                 lookup_word_break_property_from_dictionary(c),
                 c.len_utf8(),
+                TokenProperties::NON_ASCII,
             )
         };
 
@@ -81,14 +129,18 @@ pub fn tokenize(text: &str, _options: Options, mut on_breakpoint: impl FnMut(usi
                 if last_was_zwj {
                     last_was_zwj = false;
                     if WordBreakProperty::is_ext_pictographic(c) {
-                        continue; // transparent
+                        // Transparent: char joins the in-progress token instead of breaking.
+                        token_props |= char_props;
+                        continue;
                     }
                 }
                 last_was_zwj = prop == WordBreakProperty::ZWJ;
                 state = next_state;
-                if !on_breakpoint(boundary) {
+                if !on_breakpoint(boundary, std::mem::take(&mut token_props)) {
                     return;
                 }
+                // Breaking char starts the next token; apply its contribution after the take.
+                token_props |= char_props;
                 continue;
             }
             Action::NoBreak => {
@@ -102,14 +154,15 @@ pub fn tokenize(text: &str, _options: Options, mut on_breakpoint: impl FnMut(usi
                 }
                 state = next_state;
                 pos += char_len;
+                token_props |= char_props;
             }
             Action::DeferredBreak => {
                 last_was_zwj = false;
                 let boundary = deferred_break_pos.take().unwrap();
                 state = next_state;
-                // Notably, we don't advance `pos` here, current char re-examined
-                // after the next call to `next()`.
-                if !on_breakpoint(boundary) {
+                // Notably, we don't advance `pos` here; the current char is re-examined on the
+                // next iteration and will accumulate its props then — don't apply char_props here.
+                if !on_breakpoint(boundary, std::mem::take(&mut token_props)) {
                     return;
                 }
                 continue;
@@ -118,6 +171,7 @@ pub fn tokenize(text: &str, _options: Options, mut on_breakpoint: impl FnMut(usi
                 last_was_zwj = prop == WordBreakProperty::ZWJ;
                 // State doesn't change, but we still consume the character.
                 pos += char_len;
+                token_props |= char_props;
             }
         }
     }
@@ -125,13 +179,13 @@ pub fn tokenize(text: &str, _options: Options, mut on_breakpoint: impl FnMut(usi
     // Deferred state at EOT - defer failed
     if state.is_deferred() {
         let breakpoint = deferred_break_pos.take().unwrap();
-        if !on_breakpoint(breakpoint) {
+        if !on_breakpoint(breakpoint, std::mem::take(&mut token_props)) {
             return;
         }
     }
 
     // WB2: Any ÷ eot — emit final segment
-    _ = on_breakpoint(text.len());
+    _ = on_breakpoint(text.len(), token_props);
 }
 
 // Lookup table for ASCII characters, which can be processed without the DFA.
@@ -161,7 +215,7 @@ mod tests {
     fn test_word_break_against_uax29_tests() {
         let (passed, failed) =
             test_against_uax29_break_tests("testdata/WordBreakTest.txt", |s, breakpoints| {
-                tokenize(s, Options::default(), |bp| {
+                tokenize(s, Options::default(), |bp, _props| {
                     breakpoints.push(bp);
                     true
                 });
@@ -179,7 +233,7 @@ mod tests {
     fn tokenizer_sanity() {
         fn assert_breaks(s: &str, expected: Vec<usize>) {
             let mut breakpoints = Vec::new();
-            tokenize(s, Options::default(), |bp| {
+            tokenize(s, Options::default(), |bp, _props| {
                 breakpoints.push(bp);
                 true
             });
@@ -255,5 +309,27 @@ mod tests {
 
         // Circled letters
         assert_breaks("\u{200d}Ⓜ", vec![0, 6]);
+    }
+
+    #[test]
+    fn tokenizer_properties_sanity() {
+        // Each emit reports properties of the span just closed; the leading boundary at 0 has
+        // no preceding span, so it carries default props.
+        fn assert_props(s: &str, expected: Vec<(usize, bool)>) {
+            let mut got: Vec<(usize, bool)> = Vec::new();
+            tokenize(s, Options::default(), |bp, props| {
+                got.push((bp, props.is_ascii()));
+                true
+            });
+            assert_eq!(got, expected, "input: {:?}", s);
+        }
+
+        // Leading boundary at 0 is vacuously is_ascii=true.
+        assert_props("hello", vec![(0, true), (5, true)]);
+        assert_props("🛑", vec![(0, true), (4, false)]);
+
+        // The sharp case: the breaking char is non-ASCII but starts the *next* token, so "ab"
+        // must still report is_ascii=true and "🛑" must report is_ascii=false.
+        assert_props("ab🛑", vec![(0, true), (2, true), (6, false)]);
     }
 }

--- a/src/uax29/word/mod.rs
+++ b/src/uax29/word/mod.rs
@@ -237,15 +237,6 @@ const ASCII_BYTE_INFO: [u8; 128] = {
     t
 };
 
-#[unsafe(no_mangle)]
-#[inline(never)]
-pub fn _asm_probe(text: &str, out: &mut Vec<usize>) {
-    tokenize(text, Options::default(), |bp, _| {
-        out.push(bp);
-        true
-    });
-}
-
 #[cfg(test)]
 mod tests {
     use super::{Options, tokenize};

--- a/src/uax29/word/mod.rs
+++ b/src/uax29/word/mod.rs
@@ -15,7 +15,7 @@ pub struct Options {}
 /// A tokenizer that implements UAX #29 word boundary rules, using a deterministic finite automaton
 /// (DFA) to efficiently determine word boundaries in Unicode text. Includes a number of fast-paths
 /// for common cases, e.g. ASCII.
-pub fn tokenize(text: &str, breakpoints: &mut Vec<usize>, _options: Options) {
+pub fn tokenize(text: &str, _options: Options, mut on_breakpoint: impl FnMut(usize) -> bool) {
     if text.is_empty() {
         return;
     }
@@ -86,7 +86,9 @@ pub fn tokenize(text: &str, breakpoints: &mut Vec<usize>, _options: Options) {
                 }
                 last_was_zwj = prop == WordBreakProperty::ZWJ;
                 state = next_state;
-                breakpoints.push(boundary);
+                if !on_breakpoint(boundary) {
+                    return;
+                }
                 continue;
             }
             Action::NoBreak => {
@@ -107,7 +109,9 @@ pub fn tokenize(text: &str, breakpoints: &mut Vec<usize>, _options: Options) {
                 state = next_state;
                 // Notably, we don't advance `pos` here, current char re-examined
                 // after the next call to `next()`.
-                breakpoints.push(boundary);
+                if !on_breakpoint(boundary) {
+                    return;
+                }
                 continue;
             }
             Action::Transparent => {
@@ -120,11 +124,14 @@ pub fn tokenize(text: &str, breakpoints: &mut Vec<usize>, _options: Options) {
 
     // Deferred state at EOT - defer failed
     if state.is_deferred() {
-        breakpoints.push(deferred_break_pos.take().unwrap());
+        let breakpoint = deferred_break_pos.take().unwrap();
+        if !on_breakpoint(breakpoint) {
+            return;
+        }
     }
 
     // WB2: Any ÷ eot — emit final segment
-    breakpoints.push(text.len());
+    _ = on_breakpoint(text.len());
 }
 
 // Lookup table for ASCII characters, which can be processed without the DFA.
@@ -154,7 +161,10 @@ mod tests {
     fn test_word_break_against_uax29_tests() {
         let (passed, failed) =
             test_against_uax29_break_tests("testdata/WordBreakTest.txt", |s, breakpoints| {
-                tokenize(s, breakpoints, Options::default())
+                tokenize(s, Options::default(), |bp| {
+                    breakpoints.push(bp);
+                    true
+                });
             });
         assert_eq!(
             (1944, 0),
@@ -169,7 +179,10 @@ mod tests {
     fn tokenizer_sanity() {
         fn assert_breaks(s: &str, expected: Vec<usize>) {
             let mut breakpoints = Vec::new();
-            tokenize(s, &mut breakpoints, Options::default());
+            tokenize(s, Options::default(), |bp| {
+                breakpoints.push(bp);
+                true
+            });
             assert_eq!(breakpoints, expected, "input: {:?}", s);
         }
 

--- a/src/uax29/word/properties.rs
+++ b/src/uax29/word/properties.rs
@@ -1,6 +1,6 @@
 use tpuf_icu_properties_211::{
     CodePointMapData, CodePointMapDataBorrowed, CodePointSetData, CodePointSetDataBorrowed,
-    props::{ExtendedPictographic, WordBreak},
+    props::{ExtendedPictographic, GeneralCategory, Ideographic, Script, WordBreak},
 };
 
 use crate::uax29::break_property_enum;
@@ -163,6 +163,74 @@ impl WordBreakProperty {
 const WORD_BREAK_PROP: CodePointMapDataBorrowed<'static, WordBreak> =
     CodePointMapData::<WordBreak>::new();
 const EXT_PICT: CodePointSetDataBorrowed<'static> = CodePointSetData::new::<ExtendedPictographic>();
+
+/// Lazily-built union of every codepoint whose "strict" word-like check returns true:
+/// `ExtendedPictographic ∪ Ideographic ∪ {c | Script(c) ∉ {Common,Inherited,Unknown}} ∪
+/// {c | GeneralCategory(c) == OtherNumber}`.
+///
+/// Stored as a sorted slice of inclusive `(start, end)` ranges so `is_word_like_strict` is a
+/// single binary search per char instead of up to four ICU trie lookups. Built on first use.
+static WORD_LIKE_STRICT_RANGES: std::sync::OnceLock<Box<[(u32, u32)]>> = std::sync::OnceLock::new();
+
+fn word_like_strict_ranges() -> &'static [(u32, u32)] {
+    WORD_LIKE_STRICT_RANGES.get_or_init(|| {
+        let ideographic = CodePointSetData::new::<Ideographic>();
+        let script = CodePointMapData::<Script>::new();
+        let gc = CodePointMapData::<GeneralCategory>::new();
+
+        let mut ranges: Vec<(u32, u32)> = Vec::new();
+        for r in EXT_PICT.iter_ranges() {
+            ranges.push((*r.start(), *r.end()));
+        }
+        for r in ideographic.iter_ranges() {
+            ranges.push((*r.start(), *r.end()));
+        }
+        for r in script.iter_ranges_mapped(|s| {
+            !matches!(s, Script::Common | Script::Inherited | Script::Unknown)
+        }) {
+            if r.value {
+                ranges.push((*r.range.start(), *r.range.end()));
+            }
+        }
+        for r in gc.iter_ranges_for_value(GeneralCategory::OtherNumber) {
+            ranges.push((*r.start(), *r.end()));
+        }
+
+        // Sort + merge adjacent/overlapping ranges so binary search has clean buckets.
+        ranges.sort_unstable();
+        let mut merged: Vec<(u32, u32)> = Vec::with_capacity(ranges.len());
+        for (s, e) in ranges {
+            if let Some(last) = merged.last_mut() {
+                if s <= last.1.saturating_add(1) {
+                    last.1 = last.1.max(e);
+                    continue;
+                }
+            }
+            merged.push((s, e));
+        }
+        merged.into_boxed_slice()
+    })
+}
+
+/// "Strict" word-like check for chars whose `WordBreakProperty` alone didn't classify them as
+/// word-like. Mirrors the residual conditions of turbopuffer's `is_word_like_token_char` /
+/// `should_include_token_span` for non-ASCII chars not already covered by `ALetter` /
+/// `HebrewLetter` / `Numeric`.
+#[inline]
+pub(crate) fn is_word_like_strict(c: char) -> bool {
+    let cp = c as u32;
+    word_like_strict_ranges()
+        .binary_search_by(|&(s, e)| {
+            if cp < s {
+                std::cmp::Ordering::Greater
+            } else if cp > e {
+                std::cmp::Ordering::Less
+            } else {
+                std::cmp::Ordering::Equal
+            }
+        })
+        .is_ok()
+}
 
 /// Helper function to look up the Word_Break property for a given character using the pre-computed dictionary.
 #[inline(never)]

--- a/src/uax29/word/properties.rs
+++ b/src/uax29/word/properties.rs
@@ -172,6 +172,7 @@ const EXT_PICT: CodePointSetDataBorrowed<'static> = CodePointSetData::new::<Exte
 /// single binary search per char instead of up to four ICU trie lookups. Built on first use.
 static WORD_LIKE_STRICT_RANGES: std::sync::OnceLock<Box<[(u32, u32)]>> = std::sync::OnceLock::new();
 
+// See `TokenProperties::is_word_like()` for a detailed explanation of this.
 fn word_like_strict_ranges() -> &'static [(u32, u32)] {
     WORD_LIKE_STRICT_RANGES.get_or_init(|| {
         let ideographic = CodePointSetData::new::<Ideographic>();
@@ -185,6 +186,10 @@ fn word_like_strict_ranges() -> &'static [(u32, u32)] {
         for r in ideographic.iter_ranges() {
             ranges.push((*r.start(), *r.end()));
         }
+
+        // r.value is true for any range where the script is not Common/Inherited/Unknown.
+        // E.g. r.value=true when Script is a reasonable writing system (Greek, Thai, Cyrillic, etc.)
+        // This operates similar to Rust's .iter().map().filter().
         for r in script.iter_ranges_mapped(|s| {
             !matches!(s, Script::Common | Script::Inherited | Script::Unknown)
         }) {
@@ -192,6 +197,7 @@ fn word_like_strict_ranges() -> &'static [(u32, u32)] {
                 ranges.push((*r.range.start(), *r.range.end()));
             }
         }
+
         for r in gc.iter_ranges_for_value(GeneralCategory::OtherNumber) {
             ranges.push((*r.start(), *r.end()));
         }


### PR DESCRIPTION
It's a lot faster for `alyze` to determine whether or not a boundary constitutes a word-like token, because it can re-use a lot of existing logic / property checks etc. This PR exposes this information for the word tokenizer, and simultaneously yielded a speedup (I suspect because of ASCII_WORD_CONTINUE bitmask change).

```
wikipedia/word break    time:   [126.98 ms 127.04 ms 127.10 ms]
                        thrpt:  [503.53 MiB/s 503.78 MiB/s 504.02 MiB/s]
                 change:
                        time:   [−4.9777% −4.5472% −4.1364%] (p = 0.00 < 0.05)
                        thrpt:  [+4.3149% +4.7638% +5.2385%]
                        Performance has improved.
wikipedia/word break + word_like
                        time:   [127.74 ms 127.79 ms 127.84 ms]
                        thrpt:  [500.61 MiB/s 500.82 MiB/s 501.02 MiB/s]
wikipedia/sentence break
                        time:   [136.87 ms 136.94 ms 137.03 ms]
                        thrpt:  [467.04 MiB/s 467.35 MiB/s 467.60 MiB/s]
                 change:
                        time:   [−1.6506% −1.2705% −0.8961%] (p = 0.00 < 0.05)
                        thrpt:  [+0.9042% +1.2869% +1.6783%]
```

Note: Needed to add a new benchmark, because LLVM will correctly compile away all of the is_word_like functionality if `TokenProperties` is ignored in the passed closure. Quite cool!