### PR TITLE
perf: expand stemming cache

### DIFF
--- a/src/analyze/mod.rs
+++ b/src/analyze/mod.rs
@@ -121,7 +121,7 @@ impl ReusableBuffer {
         Self {
             a: String::new(),
             b: String::new(),
-            stemming_cache: StemmingCache::new_with_capacity(32_000),
+            stemming_cache: StemmingCache::new_with_capacity(128_000),
         }
     }
 

--- a/src/analyze/stemming_cache.rs
+++ b/src/analyze/stemming_cache.rs
@@ -27,7 +27,7 @@ impl StemmingCacheEntry {
 
 // We'll use a short token type to avoid caching larger tokens, which are
 // less likely to benefit from caching (rarer).
-pub type CachedToken = ShortToken<10>;
+pub type CachedToken = ShortToken<20>;
 
 impl StemmingCache {
     pub fn new_with_capacity(capacity: usize) -> Self {


### PR DESCRIPTION
Increase the reusable stemming cache capacity and cache tokens up to 20 bytes.

Bench (64 MiB Wikipedia, M4 Pro):
analysis/+ stemming: 187 -> 242 MiB/s (+29%)
analysis/full pipeline: 180 -> 228 MiB/s (+26%)

Memory trade-off:
The cache backing table grows from roughly 1.26 MiB to 9.41 MiB per ReusableBuffer, about +8.15 MiB total.