### PR TITLE
perf(analyze): skip lowercase rescan via tokenizer-computed uppercase bit

### DIFF
--- a/src/analyze/mod.rs
+++ b/src/analyze/mod.rs
@@ -163,8 +163,25 @@ impl Analyzer {
         &self,
         inputs: impl Iterator<Item = &'a str>,
         buffer: &mut ReusableBuffer,
+        callback: impl FnMut(Token<'_>) -> bool,
+    ) {
+        // Monomorphize on case sensitivity: the case-sensitive instantiation provably never
+        // lowercases, which keeps its per-token closure lean enough to stay inlined in the
+        // tokenizer's hot loop.
+        if self.options.case_sensitive {
+            self.analyze_inputs_impl::<true>(inputs, buffer, callback)
+        } else {
+            self.analyze_inputs_impl::<false>(inputs, buffer, callback)
+        }
+    }
+
+    fn analyze_inputs_impl<'a, const CASE_SENSITIVE: bool>(
+        &self,
+        inputs: impl Iterator<Item = &'a str>,
+        buffer: &mut ReusableBuffer,
         mut callback: impl FnMut(Token<'_>) -> bool,
     ) {
+        debug_assert_eq!(CASE_SENSITIVE, self.options.case_sensitive);
         let ReusableBuffer {
             a: buffer_a,
             b: buffer_b,
@@ -216,8 +233,8 @@ impl Analyzer {
                 }
 
                 // Lowercasing
-                if !self.options.case_sensitive {
-                    token_text.lowercase_in_place(props.is_ascii());
+                if !CASE_SENSITIVE {
+                    token_text.lowercase_in_place(props.is_ascii(), props.has_ascii_uppercase());
                 }
 
                 // Stopword removal
@@ -239,9 +256,9 @@ impl Analyzer {
 
                     // ASCII folding can produce uppercase ASCII characters,
                     // so we'll lowercase again if case folding is enabled.
-                    if !self.options.case_sensitive {
+                    if !CASE_SENSITIVE {
                         let is_ascii = token_text.as_str().is_ascii();
-                        token_text.lowercase_in_place(is_ascii);
+                        token_text.lowercase_in_place(is_ascii, true);
                     }
                 }
 
@@ -282,7 +299,19 @@ impl InputRefOrBuffered<'_, '_> {
         }
     }
 
-    fn lowercase_in_place(&mut self, is_ascii: bool) {
+    /// `may_have_upper` is a hint from the tokenizer: already-lowercase ASCII tokens (the
+    /// overwhelmingly common case in prose) return immediately, without rescanning the
+    /// bytes. Pass `true` when unknown.
+    #[inline(always)]
+    fn lowercase_in_place(&mut self, is_ascii: bool, may_have_upper: bool) {
+        if is_ascii && !may_have_upper {
+            debug_assert!(!self.as_str().bytes().any(|b| b.is_ascii_uppercase()));
+            return;
+        }
+        self.lowercase_in_place_slow(is_ascii);
+    }
+
+    fn lowercase_in_place_slow(&mut self, is_ascii: bool) {
         debug_assert_eq!(
             is_ascii,
             self.as_str().is_ascii(),

--- a/src/uax29/word/mod.rs
+++ b/src/uax29/word/mod.rs
@@ -21,6 +21,7 @@ pub struct TokenProperties(u8);
 impl TokenProperties {
     const WORD_LIKE_MASK: u8 = 0b0000_0001;
     const NON_ASCII_MASK: u8 = 0b0000_0010;
+    const ASCII_UPPER_MASK: u8 = 0b0000_0100;
 
     pub(crate) const NON_ASCII: Self = Self(Self::NON_ASCII_MASK);
     pub(crate) const WORD_LIKE: Self = Self(Self::WORD_LIKE_MASK);
@@ -39,6 +40,12 @@ impl TokenProperties {
     // `is_ascii()` returns true when the bit is unset (vacuously true for the empty span).
     pub fn is_ascii(&self) -> bool {
         self.0 & Self::NON_ASCII_MASK == 0
+    }
+
+    // True if the span contains an ASCII `A-Z` byte. Lets case folding skip already-lowercase
+    // ASCII tokens (the overwhelmingly common case in prose) without rescanning them.
+    pub fn has_ascii_uppercase(&self) -> bool {
+        self.0 & Self::ASCII_UPPER_MASK != 0
     }
 }
 
@@ -238,17 +245,21 @@ const WORD_BREAK_CONTRIB: [TokenProperties; WordBreakProperty::NUM_VARIANTS] = {
 
 /// Per-ASCII-byte info for the fast-path scan and the single-char branch.
 /// - Bit 7 (`ASCII_WORD_CONTINUE`): byte is part of a word-like run (`[a-zA-Z0-9_]`).
-/// - Low bits: the byte's `TokenProperties` contribution (currently just `WORD_LIKE_MASK` for
-///   `[a-zA-Z0-9]`, since underscore continues the run but isn't itself word-like).
+/// - Low bits: the byte's `TokenProperties` contribution (`WORD_LIKE_MASK` for `[a-zA-Z0-9]`
+///   — underscore continues the run but isn't itself word-like — plus `ASCII_UPPER_MASK`
+///   for `[A-Z]`).
 const ASCII_WORD_CONTINUE: u8 = 0b1000_0000;
 const ASCII_BYTE_INFO: [u8; 128] = {
     let mut t = [0u8; 128];
     let mut i = 0u8;
     loop {
         t[i as usize] = match i {
-            b'a'..=b'z' | b'A'..=b'Z' | b'0'..=b'9' => {
-                ASCII_WORD_CONTINUE | TokenProperties::WORD_LIKE_MASK
+            b'A'..=b'Z' => {
+                ASCII_WORD_CONTINUE
+                    | TokenProperties::WORD_LIKE_MASK
+                    | TokenProperties::ASCII_UPPER_MASK
             }
+            b'a'..=b'z' | b'0'..=b'9' => ASCII_WORD_CONTINUE | TokenProperties::WORD_LIKE_MASK,
             b'_' => ASCII_WORD_CONTINUE,
             _ => 0,
         };
@@ -414,6 +425,34 @@ mod tests {
         // The sharp case: the breaking char is non-ASCII but starts the *next* token, so "ab"
         // must still report is_ascii=true and "🛑" must report is_ascii=false.
         assert_props("ab🛑", vec![(0, true), (2, true), (6, false)]);
+    }
+
+    /// `has_ascii_uppercase` must reflect A-Z presence per span, on both the fast-path
+    /// scan and the DFA (mid-token punctuation) routes.
+    #[test]
+    fn tokenizer_uppercase_props() {
+        fn assert_upper(s: &str, expected: Vec<(usize, bool)>) {
+            let mut got: Vec<(usize, bool)> = Vec::new();
+            tokenize(s, Options::default(), |bp, props| {
+                got.push((bp, props.has_ascii_uppercase()));
+                true
+            });
+            assert_eq!(got, expected, "input: {:?}", s);
+        }
+
+        assert_upper("hello", vec![(0, false), (5, false)]);
+        assert_upper("Hello", vec![(0, false), (5, true)]);
+        assert_upper("heLLo", vec![(0, false), (5, true)]);
+        assert_upper("Hi lo", vec![(0, false), (2, true), (3, false), (5, false)]);
+        // Mid-token punctuation routes through the DFA; the bit must survive that path.
+        // ("e.G" holds together via WB6/WB7; the trailing "." is its own token.)
+        assert_upper(
+            "e.G. x",
+            vec![(0, false), (3, true), (4, false), (5, false), (6, false)],
+        );
+        // Mixed ASCII uppercase + non-ASCII: both bits can be set on one span.
+        assert_upper("Aé", vec![(0, false), ("Aé".len(), true)]);
+        assert_upper("éa", vec![(0, false), ("éa".len(), false)]);
     }
 
     fn assert_word_like(s: &str, expected: Vec<(usize, bool)>) {


### PR DESCRIPTION
The tokenizer already classifies every byte through ASCII_BYTE_INFO, so record "this span contains ASCII A-Z" into TokenProperties for free (one table bit; the fast-path scan and DFA accumulate it like the existing word-like bit). Case folding then skips already-lowercase ASCII tokens — the overwhelmingly common case in prose — without rescanning them.

analyze_inputs is monomorphized on case sensitivity: the case-sensitive instantiation provably never lowercases, which keeps its per-token closure lean enough to stay inlined in the tokenizer's hot loop (without the split, the extra closure code cost the case-sensitive config ~9%).

Benchmarks (M4 Pro, 64 MiB English Wikipedia, criterion median):
```
  analysis/tokenize only (case sensitive)  386 MiB/s -> 389 MiB/s
  analysis/+ lowercase                     290 MiB/s -> 320 MiB/s  (+10%)
  analysis/+ stopwords                     238 MiB/s -> 267 MiB/s  (+12%)
  analysis/+ stemming                      110 MiB/s -> 115 MiB/s  (+5%)
  analysis/full pipeline                   105 MiB/s -> 113 MiB/s  (+8%)
```
No memory impact; the bit lives in the existing TokenProperties byte.