### PR TITLE
perf: make the no-filter analyze path actually inline

### DIFF
--- a/src/analyze/filters.rs
+++ b/src/analyze/filters.rs
@@ -44,6 +44,7 @@ pub(crate) fn within_token_length_limit(s: &str, maximum_token_length: usize) ->
         && (s.len() <= maximum_token_length || s.chars().nth(maximum_token_length).is_none())
 }
 
+#[inline]
 pub(crate) fn is_stopword_in_language(language: LanguageWithStopwords, token: &str) -> bool {
     match language {
         LanguageWithStopwords::Danish => stopwords::DANISH.contains(token),

--- a/src/analyze/mod.rs
+++ b/src/analyze/mod.rs
@@ -32,6 +32,25 @@ impl AnalysisOptions {
         }
         true
     }
+
+    /// No per-token filter is configured: no length cap, stopword removal, stemming, or ASCII
+    /// folding. Selects the fast analyze monomorphization.
+    fn has_no_token_filters(&self) -> bool {
+        // Exhaustive destructure (no `..`): a new `AnalysisOptions` field won't compile until it's
+        // classified here, keeping this predicate in lockstep with the `!FAST`-gated filter blocks.
+        let AnalysisOptions {
+            tokenizer: _,
+            case_sensitive: _, // not per-token filters
+            maximum_token_length,
+            stopword_removal,
+            stemming,
+            ascii_folding,
+        } = self;
+        maximum_token_length.is_none()
+            && stopword_removal.is_none()
+            && stemming.is_none()
+            && !*ascii_folding
+    }
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -165,6 +184,22 @@ impl Analyzer {
         &self,
         inputs: impl Iterator<Item = &'a str>,
         buffer: &mut ReusableBuffer,
+        callback: impl FnMut(Token<'_>) -> bool,
+    ) {
+        // On the FAST path every filter block `const`-eliminates, shrinking the per-breakpoint
+        // closure enough for LLVM to inline it into the tokenizer and drop the per-token call
+        // boundary.
+        if self.options.has_no_token_filters() {
+            self.analyze_dispatch::<true>(inputs, buffer, callback);
+        } else {
+            self.analyze_dispatch::<false>(inputs, buffer, callback);
+        }
+    }
+
+    fn analyze_dispatch<'a, const FAST: bool>(
+        &self,
+        inputs: impl Iterator<Item = &'a str>,
+        buffer: &mut ReusableBuffer,
         mut callback: impl FnMut(Token<'_>) -> bool,
     ) {
         let ReusableBuffer {
@@ -173,10 +208,16 @@ impl Analyzer {
             stemming_cache,
         } = buffer;
 
-        let stemmer = self.options.stemming.map(|stemming_language| {
-            let algorithm = stemming_language.into();
-            rust_stemmers::Stemmer::create(algorithm)
-        });
+        // Gated on `!FAST` so the allocating `Stemmer::create` is statically dead on the fast path
+        // and `stemmer` folds to `None`.
+        let stemmer = if !FAST {
+            self.options.stemming.map(|stemming_language| {
+                let algorithm = stemming_language.into();
+                rust_stemmers::Stemmer::create(algorithm)
+            })
+        } else {
+            None
+        };
 
         // Monotonic across all inputs. Every word-like token consumes
         // a position, even if a downstream filter (length, stopword) drops it,
@@ -211,7 +252,8 @@ impl Analyzer {
                 };
 
                 // Token length
-                if let Some(max_token_length) = self.options.maximum_token_length
+                if !FAST
+                    && let Some(max_token_length) = self.options.maximum_token_length
                     && !filters::within_token_length_limit(token_text.as_str(), max_token_length)
                 {
                     return true;
@@ -222,28 +264,32 @@ impl Analyzer {
                     token_text.lowercase_in_place(props.is_ascii());
                 }
 
-                // Stopword removal
-                if let Some(StopwordRemoval::ForLanguage(language)) = self.options.stopword_removal
-                    && filters::is_stopword_in_language(language, token_text.as_str())
-                {
-                    return true;
-                }
+                // Post-lowercase filters; the whole block `const`-eliminates under `FAST`.
+                if !FAST {
+                    // Stopword removal
+                    if let Some(StopwordRemoval::ForLanguage(language)) =
+                        self.options.stopword_removal
+                        && filters::is_stopword_in_language(language, token_text.as_str())
+                    {
+                        return true;
+                    }
 
-                // Stemming
-                if let Some(stemmer) = &stemmer {
-                    token_text.stem_in_place(stemmer, stemming_cache, buffer_b);
-                }
+                    // Stemming
+                    if let Some(stemmer) = &stemmer {
+                        token_text.stem_in_place(stemmer, stemming_cache, buffer_b);
+                    }
 
-                // ASCII folding
-                // Note: Not needed if token is already ASCII
-                if self.options.ascii_folding && !props.is_ascii() {
-                    token_text.ascii_fold_in_place(buffer_b);
+                    // ASCII folding
+                    // Note: Not needed if token is already ASCII
+                    if self.options.ascii_folding && !props.is_ascii() {
+                        token_text.ascii_fold_in_place(buffer_b);
 
-                    // ASCII folding can produce uppercase ASCII characters,
-                    // so we'll lowercase again if case folding is enabled.
-                    if !self.options.case_sensitive {
-                        let is_ascii = token_text.as_str().is_ascii();
-                        token_text.lowercase_in_place(is_ascii);
+                        // ASCII folding can produce uppercase ASCII characters,
+                        // so we'll lowercase again if case folding is enabled.
+                        if !self.options.case_sensitive {
+                            let is_ascii = token_text.as_str().is_ascii();
+                            token_text.lowercase_in_place(is_ascii);
+                        }
                     }
                 }
 

--- a/src/uax29/word/mod.rs
+++ b/src/uax29/word/mod.rs
@@ -52,6 +52,9 @@ impl std::ops::BitOrAssign for TokenProperties {
 /// A tokenizer that implements UAX #29 word boundary rules, using a deterministic finite automaton
 /// (DFA) to efficiently determine word boundaries in Unicode text. Includes a number of fast-paths
 /// for common cases, e.g. ASCII.
+// `#[inline]` so the DFA loop fuses with the caller's per-breakpoint closure: `analyze`'s fast path
+// needs that closure inlined here to drop the per-token call boundary.
+#[inline]
 pub fn tokenize(
     text: &str,
     _options: Options,


### PR DESCRIPTION
When no per-token filter is configured, analyze has almost nothing to do per token, yet it was still paying a function call per token because the tokenizer's closure wasn't getting inlined into the DFA loop.

Two changes get it inlined:
- A `FAST` const generic so the no-filter case drops every filter branch, leaving a small closure.
- `#[inline]` on the word tokenizer, so the loop and the closure fuse no matter the closure size. The const split alone isn't quite enough, since the closure still builds the Token (byte range and friends).

Also inlined the stopword lookup so the per-language check stays in the hot path.

64 MiB English Wikipedia, Ryzen 9 5950X, criterion:

-   tokenize only:  269 -> 343 MiB/s  (+27%)
-   \+ lowercase:    212 -> 243 MiB/s  (+15%)
-   \+ stopwords:    182 -> 196 MiB/s  (+8%)
-   full pipeline:   84 ->  87 MiB/s  (+4%)

Checked the fusion actually lands: the release binary has no `tokenize` symbols left (fully inlined everywhere), and the fast path's closure has no out-of-line symbol while the slow path's does -- exactly the split we want. So plain `#[inline]` is enough; `#[inline(always)]` would only force it into the slow and bench paths and make the regression above worse.