### PR TITLE
perf improvements

### DIFF
--- a/src/analyze/filters.rs
+++ b/src/analyze/filters.rs
@@ -39,9 +39,21 @@ pub(crate) fn lowercase_chars_in_place(s: &mut String) {
     s.drain(..original_byte_length);
 }
 
-pub(crate) fn within_token_length_limit(s: &str, maximum_token_length: usize) -> bool {
-    maximum_token_length > 0
-        && (s.len() <= maximum_token_length || s.chars().nth(maximum_token_length).is_none())
+pub(crate) fn within_token_length_limit(
+    s: &str,
+    maximum_token_length: usize,
+    is_ascii: bool,
+) -> bool {
+    if maximum_token_length == 0 {
+        return false;
+    }
+    if s.len() <= maximum_token_length {
+        return true;
+    }
+    if is_ascii {
+        return false;
+    }
+    s.chars().nth(maximum_token_length).is_none()
 }
 
 pub(crate) fn is_stopword_in_language(language: LanguageWithStopwords, token: &str) -> bool {

--- a/src/analyze/mod.rs
+++ b/src/analyze/mod.rs
@@ -212,14 +212,22 @@ impl Analyzer {
 
                 // Token length
                 if let Some(max_token_length) = self.options.maximum_token_length
-                    && !filters::within_token_length_limit(token_text.as_str(), max_token_length)
+                    && !filters::within_token_length_limit(
+                        token_text.as_str(),
+                        max_token_length,
+                        props.is_ascii(),
+                    )
                 {
                     return true;
                 }
 
                 // Lowercasing
                 if !self.options.case_sensitive {
-                    token_text.lowercase_in_place(props.is_ascii());
+                    let is_ascii = props.is_ascii();
+                    token_text.lowercase_in_place(
+                        is_ascii,
+                        is_ascii && !props.has_ascii_uppercase(),
+                    );
                 }
 
                 // Stopword removal
@@ -243,7 +251,10 @@ impl Analyzer {
                     // so we'll lowercase again if case folding is enabled.
                     if !self.options.case_sensitive {
                         let is_ascii = token_text.as_str().is_ascii();
-                        token_text.lowercase_in_place(is_ascii);
+                        token_text.lowercase_in_place(
+                            is_ascii,
+                            is_ascii && !token_text.as_str().bytes().any(|b| b.is_ascii_uppercase()),
+                        );
                     }
                 }
 
@@ -295,14 +306,14 @@ impl InputRefOrBuffered<'_, '_> {
         }
     }
 
-    fn lowercase_in_place(&mut self, is_ascii: bool) {
+    fn lowercase_in_place(&mut self, is_ascii: bool, ascii_already_lowercase: bool) {
         debug_assert_eq!(
             is_ascii,
             self.as_str().is_ascii(),
             "caller must ensure is_ascii is correct"
         );
 
-        if is_ascii && self.as_str().bytes().all(|b| !b.is_ascii_uppercase()) {
+        if is_ascii && ascii_already_lowercase {
             return;
         }
 

--- a/src/uax29/word/mod.rs
+++ b/src/uax29/word/mod.rs
@@ -8,6 +8,11 @@ use properties::{
 };
 use transitions::{State, TABLE, Transition};
 
+const ASCII_WORD_SCAN_STATES: u16 = (1 << State::ALetter as u16)
+    | (1 << State::Numeric as u16)
+    | (1 << State::HLetter as u16)
+    | (1 << State::ExtendNumLet as u16);
+
 /// For backwards compatibility, require caller to pass in options struct.
 #[derive(Default, Clone, Copy, Debug)]
 #[non_exhaustive]
@@ -21,6 +26,7 @@ pub struct TokenProperties(u8);
 impl TokenProperties {
     const WORD_LIKE_MASK: u8 = 0b0000_0001;
     const NON_ASCII_MASK: u8 = 0b0000_0010;
+    const ASCII_UPPERCASE_MASK: u8 = 0b0000_0100;
 
     pub(crate) const NON_ASCII: Self = Self(Self::NON_ASCII_MASK);
     pub(crate) const WORD_LIKE: Self = Self(Self::WORD_LIKE_MASK);
@@ -40,6 +46,10 @@ impl TokenProperties {
     pub fn is_ascii(&self) -> bool {
         self.0 & Self::NON_ASCII_MASK == 0
     }
+
+    pub(crate) fn has_ascii_uppercase(&self) -> bool {
+        self.0 & Self::ASCII_UPPERCASE_MASK != 0
+    }
 }
 
 impl std::ops::BitOrAssign for TokenProperties {
@@ -52,6 +62,7 @@ impl std::ops::BitOrAssign for TokenProperties {
 /// A tokenizer that implements UAX #29 word boundary rules, using a deterministic finite automaton
 /// (DFA) to efficiently determine word boundaries in Unicode text. Includes a number of fast-paths
 /// for common cases, e.g. ASCII.
+#[inline]
 pub fn tokenize(
     text: &str,
     _options: Options,
@@ -90,10 +101,7 @@ pub fn tokenize(
     while pos < text.len() {
         // Fast path for ASCII, e.g. skip DFA all together when possible.
         // Roughly a ~2x speedup on English Wikipedia.
-        if matches!(
-            state,
-            State::ALetter | State::Numeric | State::ExtendNumLet | State::HLetter
-        ) {
+        if (ASCII_WORD_SCAN_STATES >> (state as u8)) & 1 != 0 {
             let scan_start = pos;
             let mut fast_acc: u8 = 0;
             while pos < text.len() && bytes[pos] < 0x80 {
@@ -239,15 +247,20 @@ const WORD_BREAK_CONTRIB: [TokenProperties; WordBreakProperty::NUM_VARIANTS] = {
 /// Per-ASCII-byte info for the fast-path scan and the single-char branch.
 /// - Bit 7 (`ASCII_WORD_CONTINUE`): byte is part of a word-like run (`[a-zA-Z0-9_]`).
 /// - Low bits: the byte's `TokenProperties` contribution (currently just `WORD_LIKE_MASK` for
-///   `[a-zA-Z0-9]`, since underscore continues the run but isn't itself word-like).
+///   `[a-zA-Z0-9]`, since underscore continues the run but isn't itself word-like. Also adds`ASCII_UPPERCASE_MASK` to track uppercase for fast-path lowercasing later).
 const ASCII_WORD_CONTINUE: u8 = 0b1000_0000;
 const ASCII_BYTE_INFO: [u8; 128] = {
     let mut t = [0u8; 128];
     let mut i = 0u8;
     loop {
         t[i as usize] = match i {
-            b'a'..=b'z' | b'A'..=b'Z' | b'0'..=b'9' => {
+            b'a'..=b'z' | b'0'..=b'9' => {
                 ASCII_WORD_CONTINUE | TokenProperties::WORD_LIKE_MASK
+            }
+            b'A'..=b'Z' => {
+                ASCII_WORD_CONTINUE
+                    | TokenProperties::WORD_LIKE_MASK
+                    | TokenProperties::ASCII_UPPERCASE_MASK
             }
             b'_' => ASCII_WORD_CONTINUE,
             _ => 0,


### PR DESCRIPTION
Adds two optimizations:
1. Fast-path for token length limit check (if it's ascii we can just check byte length and return early
2. Keep track of uppercase ascii to conditionally skip lowercasing (we're iterating over the bytes anyway in the tokenizer)
3. Swap the `matches!` macro to bitshifts of state. This one has the smallest impact on benchmarks so might not be worth the added code complexity.

Benchmark results on my Macbook M4:

````
wikipedia/word break
                        time:   [144.55 ms 147.89 ms 152.81 ms]
                        thrpt:  [418.83 MiB/s 432.75 MiB/s 442.76 MiB/s]
                 change:
                        time:   [−11.976% −8.4151% −4.4599%] (p = 0.00 < 0.05)
                        thrpt:  [+4.6681% +9.1883% +13.605%]
                        Performance has improved.

wikipedia/word break + word_like
                        time:   [159.64 ms 164.54 ms 169.84 ms]
                        thrpt:  [376.83 MiB/s 388.97 MiB/s 400.90 MiB/s]
                 change:
                        time:   [−8.2448% −4.7306% −0.9079%] (p = 0.02 < 0.05)
                        thrpt:  [+0.9162% +4.9655% +8.9857%]
                        Change within noise threshold.

wikipedia/sentence break
                        time:   [161.09 ms 163.49 ms 165.82 ms]
                        thrpt:  [385.96 MiB/s 391.46 MiB/s 397.29 MiB/s]
                 change:
                        time:   [−10.619% −5.3155% −0.5601%] (p = 0.06 > 0.05)
                        thrpt:  [+0.5633% +5.6139% +11.881%]
                        No change in performance detected.

analysis/tokenize only (case sensitive)
                        time:   [210.56 ms 215.33 ms 222.91 ms]
                        thrpt:  [287.11 MiB/s 297.22 MiB/s 303.95 MiB/s]
                 change:
                        time:   [−6.1056% −2.5190% +1.8109%] (p = 0.26 > 0.05)
                        thrpt:  [−1.7787% +2.5841% +6.5026%]
                        No change in performance detected.

analysis/+ lowercase
                        time:   [235.18 ms 235.88 ms 236.60 ms]
                        thrpt:  [270.49 MiB/s 271.33 MiB/s 272.13 MiB/s]
                 change:
                        time:   [−15.639% −14.701% −13.762%] (p = 0.00 < 0.05)
                        thrpt:  [+15.958% +17.235% +18.538%]
                        Performance has improved.

analysis/+ stopwords
                        time:   [280.41 ms 283.98 ms 288.10 ms]
                        thrpt:  [222.14 MiB/s 225.37 MiB/s 228.24 MiB/s]
                 change:
                        time:   [−11.421% −9.7104% −8.0149%] (p = 0.00 < 0.05)
                        thrpt:  [+8.7133% +10.755% +12.894%]
                        Performance has improved.

analysis/+ stemming
                        time:   [612.28 ms 614.68 ms 617.11 ms]
                        thrpt:  [103.71 MiB/s 104.12 MiB/s 104.53 MiB/s]
                 change:
                        time:   [−4.8776% −3.8804% −2.9715%] (p = 0.00 < 0.05)
                        thrpt:  [+3.0625% +4.0371% +5.1277%]
                        Performance has improved.

analysis/full pipeline
                        time:   [639.85 ms 644.12 ms 650.34 ms]
                        thrpt:  [98.410 MiB/s 99.360 MiB/s 100.02 MiB/s]
                 change:
                        time:   [−7.3927% −4.5102% −2.3039%] (p = 0.00 < 0.05)
                        thrpt:  [+2.3582% +4.7232% +7.9829%]
                        Performance has improved.
````