### PR TITLE
Lazy tokenization/analysis + clippy

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,34 @@ lowercasing, ASCII case folding, stemming & stopword removal.
 
 Currently in production at [turbopuffer](https://turbopuffer.com) powering the `word_v4` tokenizer.
 
+### Usage
+
+Analysis is available as a lazy lending stream, so normalized token text can reuse an allocation
+without being copied into every result:
+
+```rust
+use alyze::analyze::{
+    AnalysisOptions, Analyzer, ReusableBuffer, TokenizerOptions,
+};
+
+let analyzer = Analyzer::new(AnalysisOptions {
+    tokenizer: TokenizerOptions::UAX29Word(Default::default()),
+    maximum_token_length: None,
+    case_sensitive: false,
+    stopword_removal: None,
+    stemming: None,
+    ascii_folding: false,
+});
+let mut buffer = ReusableBuffer::new();
+let mut stream = analyzer.token_stream("Hello, world!", &mut buffer);
+
+while let Some(token) = stream.next_token() {
+    println!("{} at position {}", token.text, token.position);
+}
+```
+
+`Analyzer::analyze` and `Analyzer::analyze_inputs` provide equivalent callback-based APIs.
+
 ### Benchmarks
 
 Throughput over 64 MiB of English Wikipedia article text (`cargo bench`), running on an M5 Pro.

--- a/benches/wikipedia.rs
+++ b/benches/wikipedia.rs
@@ -152,6 +152,19 @@ pub fn analysis_benchmark(c: &mut Criterion) {
                 std::hint::black_box(&count);
             })
         });
+        group.bench_function(format!("{name} (stream)"), |b| {
+            b.iter(|| {
+                let mut count = 0;
+                for text in &texts {
+                    let mut stream = analyzer.token_stream(text, &mut buffer);
+                    while let Some(token) = stream.next_token() {
+                        count += 1;
+                        std::hint::black_box(&token.text);
+                    }
+                }
+                std::hint::black_box(&count);
+            })
+        });
     }
 
     group.finish();

--- a/benches/wikipedia.rs
+++ b/benches/wikipedia.rs
@@ -1,20 +1,14 @@
-use std::{
-    fs::File,
-    io::Write,
-    path::{Path, PathBuf},
-};
-
 use alyze::analyze::{
     AnalysisOptions, Analyzer, LanguageWithStopwords, ReusableBuffer, StemmingLanguage,
     StopwordRemoval, TokenizerOptions,
 };
 use alyze::uax29;
 use criterion::{Criterion, Throughput, criterion_group, criterion_main};
-use parquet::{
-    file::reader::{FileReader, SerializedFileReader},
-    record::{Row, RowAccessor, reader::RowIter},
-    schema::types::Type,
-};
+
+#[path = "../dev/wikipedia.rs"]
+#[allow(dead_code)]
+mod wikipedia_data;
+use wikipedia_data::{CHUNK_BYTES, load_n_bytes};
 
 criterion_group!(benches, wikipedia_benchmark, analysis_benchmark);
 criterion_main!(benches);
@@ -22,7 +16,7 @@ criterion_main!(benches);
 pub fn wikipedia_benchmark(c: &mut Criterion) {
     let mut group = c.benchmark_group("wikipedia");
 
-    let n_bytes = 64 << 20; // 64 MiB
+    let n_bytes = CHUNK_BYTES;
     let texts = load_n_bytes(n_bytes);
 
     group.throughput(Throughput::Bytes(n_bytes));
@@ -79,7 +73,7 @@ pub fn wikipedia_benchmark(c: &mut Criterion) {
 pub fn analysis_benchmark(c: &mut Criterion) {
     let mut group = c.benchmark_group("analysis");
 
-    let n_bytes = 64 << 20; // 64 MiB
+    let n_bytes = CHUNK_BYTES;
     let texts = load_n_bytes(n_bytes);
 
     group.throughput(Throughput::Bytes(n_bytes));
@@ -168,86 +162,4 @@ pub fn analysis_benchmark(c: &mut Criterion) {
     }
 
     group.finish();
-}
-
-fn load_n_bytes(n: u64) -> Vec<String> {
-    let cache_dir = cache_dir();
-    let files_and_urls = parquet_files_and_urls();
-    let mut texts = Vec::new();
-    let mut total_bytes = 0;
-    for (file_name, url) in files_and_urls {
-        let file = download_file_with_cache(&file_name, &url, &cache_dir);
-        let reader = SerializedFileReader::new(file).expect("failed to create parquet reader");
-        let rows = iter_parquet_rows(Box::new(reader), &["text"]);
-        for row in rows {
-            let text = row.get_string(0).cloned().unwrap();
-            total_bytes += text.len() as u64;
-            texts.push(text);
-            if total_bytes >= n {
-                return texts;
-            }
-        }
-    }
-    panic!("not enough data in parquet files to reach {} bytes", n);
-}
-
-fn cache_dir() -> PathBuf {
-    let dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(".cache/wikipedia");
-    std::fs::create_dir_all(&dir).expect("failed to create cache directory");
-    dir
-}
-
-fn parquet_files_and_urls() -> Vec<(String, String)> {
-    let mut files_and_urls = Vec::new();
-    for i in 0..41 {
-        let file = format!("train-{:05}-of-00041.parquet", i);
-        let url = format!(
-            "https://huggingface.co/datasets/wikimedia/wikipedia/resolve/main/20231101.en/{}?download=true",
-            file
-        );
-        files_and_urls.push((file, url));
-    }
-    files_and_urls
-}
-
-fn download_file_with_cache(file_name: &str, url: &str, cache_dir: &Path) -> File {
-    let cache_file = cache_dir.join(file_name);
-    if !cache_file.exists() {
-        println!(
-            "wikipedia: downloading '{}' (from {}) for benchmark",
-            file_name, url
-        );
-        let response = ureq::get(url).call().expect("failed to download file");
-        let mut tmp_file = tempfile::Builder::new()
-            .tempfile_in(cache_dir)
-            .expect("failed to create temporary file");
-        std::io::copy(&mut response.into_body().into_reader(), &mut tmp_file)
-            .expect("failed to write response body to temporary file");
-        tmp_file
-            .as_file_mut()
-            .flush()
-            .expect("failed to flush temporary file");
-        tmp_file
-            .persist(&cache_file)
-            .expect("rename failed to move temporary file to cache");
-    }
-    File::open(cache_file).expect("failed to open cached file")
-}
-
-fn iter_parquet_rows(
-    reader: Box<dyn FileReader>,
-    column_names: &[&str],
-) -> impl Iterator<Item = Row> {
-    let parquet_metadata = reader.metadata();
-    let fields = parquet_metadata.file_metadata().schema().get_fields();
-    let mut selected_fields = fields.to_vec();
-    selected_fields.retain(|f| column_names.contains(&f.name()));
-    let schema_proj = Type::group_type_builder("schema")
-        .with_fields(selected_fields)
-        .build()
-        .unwrap();
-    RowIter::from_file_into(reader)
-        .project(Some(schema_proj))
-        .unwrap()
-        .map(|result| result.unwrap())
 }

--- a/dev/wikipedia.rs
+++ b/dev/wikipedia.rs
@@ -1,0 +1,122 @@
+use std::{
+    fs::File,
+    io::Write,
+    path::{Path, PathBuf},
+};
+
+use parquet::{
+    file::reader::{FileReader, SerializedFileReader},
+    record::{Row, RowAccessor, reader::RowIter},
+    schema::types::Type,
+};
+
+pub const SHARD_COUNT: usize = 41;
+pub const CHUNK_BYTES: u64 = 64 << 20;
+
+pub fn load_n_bytes(n: u64) -> Vec<String> {
+    let mut texts = Vec::new();
+    let mut total_bytes = 0;
+    visit_texts(0..SHARD_COUNT, |text| {
+        total_bytes += text.len() as u64;
+        texts.push(text);
+        total_bytes < n
+    });
+    assert!(
+        total_bytes >= n,
+        "Wikipedia dataset is smaller than {n} bytes"
+    );
+    texts
+}
+
+#[allow(unused)]
+pub fn visit_chunks(
+    files: impl IntoIterator<Item = usize>,
+    chunk_bytes: u64,
+    mut visit: impl FnMut(usize, usize, &[String]) -> bool,
+) {
+    for file_index in files {
+        let mut texts = Vec::new();
+        let mut total_bytes = 0;
+        let mut chunk_index = 0;
+        let mut keep_going = true;
+        visit_texts(file_index..file_index + 1, |text| {
+            total_bytes += text.len() as u64;
+            texts.push(text);
+            if total_bytes >= chunk_bytes {
+                keep_going = visit(file_index, chunk_index, &texts);
+                texts.clear();
+                total_bytes = 0;
+                chunk_index += 1;
+            }
+            keep_going
+        });
+        if !keep_going {
+            return;
+        }
+        if !texts.is_empty() && !visit(file_index, chunk_index, &texts) {
+            return;
+        }
+    }
+}
+
+fn visit_texts(files: impl IntoIterator<Item = usize>, mut visit: impl FnMut(String) -> bool) {
+    for index in files {
+        assert!(index < SHARD_COUNT, "invalid Wikipedia shard {index}");
+        let reader = SerializedFileReader::new(wikipedia_file(index))
+            .expect("failed to create Wikipedia parquet reader");
+        for row in text_rows(Box::new(reader)) {
+            if !visit(row.get_string(0).unwrap().clone()) {
+                return;
+            }
+        }
+    }
+}
+
+fn wikipedia_file(index: usize) -> File {
+    let file_name = format!("train-{index:05}-of-{SHARD_COUNT:05}.parquet");
+    let cache_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(".cache/wikipedia");
+    std::fs::create_dir_all(&cache_dir).expect("failed to create Wikipedia cache directory");
+    let path = cache_dir.join(&file_name);
+    if !path.exists() {
+        download(&file_name, &path);
+    }
+    File::open(path).expect("failed to open cached Wikipedia shard")
+}
+
+fn download(file_name: &str, path: &Path) {
+    let url = format!(
+        "https://huggingface.co/datasets/wikimedia/wikipedia/resolve/main/20231101.en/{file_name}?download=true"
+    );
+    println!("wikipedia: downloading '{file_name}' from {url}");
+    let response = ureq::get(&url)
+        .call()
+        .expect("failed to download Wikipedia shard");
+    let mut temp = tempfile::Builder::new()
+        .tempfile_in(path.parent().unwrap())
+        .expect("failed to create temporary Wikipedia cache file");
+    std::io::copy(&mut response.into_body().into_reader(), &mut temp)
+        .expect("failed to write Wikipedia shard");
+    temp.as_file_mut()
+        .flush()
+        .expect("failed to flush Wikipedia shard");
+    temp.persist(path)
+        .expect("failed to move Wikipedia shard into cache");
+}
+
+fn text_rows(reader: Box<dyn FileReader>) -> impl Iterator<Item = Row> {
+    let metadata = reader.metadata();
+    let fields = metadata.file_metadata().schema().get_fields();
+    let text_fields = fields
+        .iter()
+        .filter(|field| field.name() == "text")
+        .cloned()
+        .collect();
+    let projection = Type::group_type_builder("schema")
+        .with_fields(text_fields)
+        .build()
+        .unwrap();
+    RowIter::from_file_into(reader)
+        .project(Some(projection))
+        .unwrap()
+        .map(Result::unwrap)
+}

--- a/src/analyze/filters.rs
+++ b/src/analyze/filters.rs
@@ -10,7 +10,7 @@ pub(crate) fn lowercase_chars_in_place(s: &mut String) {
     // Pad the string with enough space for the full lowercased output.
     // Lowercasing will, at most, expand each character to `MAX_LOWERCASED_BYTE_LENGTH` bytes.
     let additional_scratch = s.chars().count() * MAX_LOWERCASED_BYTE_LENGTH;
-    s.extend(std::iter::repeat('\0').take(additional_scratch));
+    s.extend(std::iter::repeat_n('\0', additional_scratch));
 
     // Split the string into two parts, the original and lowercased part.
     // We'll read from the original part and write to the lowercased part.

--- a/src/analyze/mod.rs
+++ b/src/analyze/mod.rs
@@ -150,119 +150,247 @@ impl Analyzer {
 
     /// Analyzes a single input string, invoking the callback for each token.
     /// Returning false from the callback will stop analysis early.
+    #[inline(always)]
     pub fn analyze<'a>(
         &self,
         input: &'a str,
         buffer: &mut ReusableBuffer,
-        callback: impl FnMut(Token<'_>) -> bool,
+        mut callback: impl FnMut(Token<'_>) -> bool,
     ) {
-        self.analyze_inputs(std::iter::once(input), buffer, callback);
+        let mut stream = self.token_stream(input, buffer);
+        while let Some(token) = stream.next_token() {
+            if !callback(token) {
+                break;
+            }
+        }
     }
 
     /// Analyzes a sequence of input strings, invoking the callback for each token.
     /// Returning false from the callback will stop analysis early.
+    #[inline(always)]
     pub fn analyze_inputs<'a>(
         &self,
         inputs: impl Iterator<Item = &'a str>,
         buffer: &mut ReusableBuffer,
         mut callback: impl FnMut(Token<'_>) -> bool,
     ) {
-        let ReusableBuffer {
-            a: buffer_a,
-            b: buffer_b,
-            stemming_cache,
-        } = buffer;
+        let mut stream = self.token_stream_inputs(inputs, buffer);
+        while let Some(token) = stream.next_token() {
+            if !callback(token) {
+                break;
+            }
+        }
+    }
+
+    /// Lazily analyzes a single input string.
+    #[inline(always)]
+    pub fn token_stream<'input, 'buffer>(
+        &self,
+        input: &'input str,
+        buffer: &'buffer mut ReusableBuffer,
+    ) -> TokenStream<'input, 'buffer, std::iter::Once<&'input str>> {
+        self.token_stream_inputs(std::iter::once(input), buffer)
+    }
+
+    /// Lazily analyzes a sequence of input strings.
+    #[inline(always)]
+    pub fn token_stream_inputs<'input, 'buffer, I>(
+        &self,
+        inputs: I,
+        buffer: &'buffer mut ReusableBuffer,
+    ) -> TokenStream<'input, 'buffer, I>
+    where
+        I: Iterator<Item = &'input str>,
+    {
+        let TokenizerOptions::UAX29Word(tokenizer_options) = self.options.tokenizer;
 
         let stemmer = self.options.stemming.map(|stemming_language| {
             let algorithm = stemming_language.into();
             rust_stemmers::Stemmer::create(algorithm)
         });
 
-        // Monotonic across all inputs. Every word-like token consumes
-        // a position, even if a downstream filter (length, stopword) drops it,
-        // which is important for phrase-distance accuracy.
-        //
-        // TODO configurable gap between inputs
-        let mut next_position = 0;
+        TokenStream {
+            options: self.options,
+            tokenizer_options,
+            inputs: inputs.enumerate(),
+            buffer,
+            stemmer,
+            next_position: 0,
+            current_input: None,
+            current_input_index: 0,
+            breakpoints: None,
+            previous_breakpoint: None,
+            current_token: None,
+        }
+    }
+}
 
-        let TokenizerOptions::UAX29Word(tokenizer_opts) = self.options.tokenizer;
+/// A lazy stream of analyzed tokens.
+///
+/// Call [`advance`](Self::advance), then inspect the current token with
+/// [`token`](Self::token). The returned token is valid until the next mutable
+/// operation on the stream. This is a lending stream rather than an
+/// [`Iterator`] because token text may borrow from the reusable buffer.
+pub struct TokenStream<'input, 'buffer, I>
+where
+    I: Iterator<Item = &'input str>,
+{
+    options: AnalysisOptions,
+    tokenizer_options: uax29::word::Options,
+    inputs: std::iter::Enumerate<I>,
+    buffer: &'buffer mut ReusableBuffer,
+    stemmer: Option<rust_stemmers::Stemmer>,
+    next_position: usize,
+    current_input: Option<&'input str>,
+    current_input_index: usize,
+    breakpoints: Option<uax29::word::Breakpoints<'input>>,
+    previous_breakpoint: Option<usize>,
+    current_token: Option<CurrentToken<'input>>,
+}
 
-        for (input_index, input) in inputs.enumerate() {
-            let mut prev = None;
-            let input_as_bytes = input.as_bytes();
-            uax29::word::tokenize(input, tokenizer_opts, |bp, props| {
-                let Some(prev) = std::mem::replace(&mut prev, Some(bp)) else {
-                    return true; // don't emit token on first breakpoint
+impl<'input, I> TokenStream<'input, '_, I>
+where
+    I: Iterator<Item = &'input str>,
+{
+    /// Advances to the next analyzed token.
+    #[inline(always)]
+    pub fn advance(&mut self) -> bool {
+        self.current_token = None;
+
+        loop {
+            if self.breakpoints.is_none() {
+                let Some((input_index, input)) = self.inputs.next() else {
+                    return false;
                 };
-                if !props.is_word_like() {
-                    return true; // skip non-word tokens
-                }
+                self.current_input = Some(input);
+                self.current_input_index = input_index;
+                self.breakpoints = Some(uax29::word::breakpoints(input, self.tokenizer_options));
+                self.previous_breakpoint = None;
+            }
 
-                // Advance position after each word-like token.
-                let position = next_position;
-                next_position += 1;
+            let Some((breakpoint, properties)) = self.breakpoints.as_mut().unwrap().next() else {
+                self.breakpoints = None;
+                self.current_input = None;
+                continue;
+            };
+            let Some(previous_breakpoint) = self.previous_breakpoint.replace(breakpoint) else {
+                continue;
+            };
+            if !properties.is_word_like() {
+                continue;
+            }
 
-                // SAFETY: tokenize guarentees that breakpoints are on valid UTF-8 boundaries,
-                // thus slicing input by the breakpoint will always produce valid UTF-8.
+            // Monotonic across all inputs. Every word-like token consumes a
+            // position, even if a downstream filter drops it.
+            let position = self.next_position;
+            self.next_position += 1;
+
+            let input = self.current_input.unwrap();
+            let input_as_bytes = input.as_bytes();
+            let text = {
+                let ReusableBuffer {
+                    a: buffer_a,
+                    b: buffer_b,
+                    stemming_cache,
+                } = &mut *self.buffer;
+
+                // SAFETY: word breakpoints are always valid UTF-8 boundaries.
                 buffer_a.clear();
                 let mut token_text = InputRefOrBuffered::InputRef {
-                    input: unsafe { std::str::from_utf8_unchecked(&input_as_bytes[prev..bp]) },
+                    input: unsafe {
+                        std::str::from_utf8_unchecked(
+                            &input_as_bytes[previous_breakpoint..breakpoint],
+                        )
+                    },
                     buffer_if_needed: buffer_a,
                 };
 
-                // Token length
                 if let Some(max_token_length) = self.options.maximum_token_length
                     && !filters::within_token_length_limit(token_text.as_str(), max_token_length)
                 {
-                    return true;
+                    continue;
                 }
 
-                // Lowercasing
                 if !self.options.case_sensitive {
-                    token_text.lowercase_in_place(props.is_ascii());
+                    token_text.lowercase_in_place(properties.is_ascii());
                 }
 
-                // Stopword removal
                 if let Some(StopwordRemoval::ForLanguage(language)) = self.options.stopword_removal
                     && filters::is_stopword_in_language(language, token_text.as_str())
                 {
-                    return true;
+                    continue;
                 }
 
-                // Stemming
-                if let Some(stemmer) = &stemmer {
+                if let Some(stemmer) = &self.stemmer {
                     token_text.stem_in_place(stemmer, stemming_cache, buffer_b);
                 }
 
-                // ASCII folding
-                // Note: Not needed if token is already ASCII
-                if self.options.ascii_folding && !props.is_ascii() {
+                if self.options.ascii_folding && !properties.is_ascii() {
                     token_text.ascii_fold_in_place(buffer_b);
-
-                    // ASCII folding can produce uppercase ASCII characters,
-                    // so we'll lowercase again if case folding is enabled.
                     if !self.options.case_sensitive {
                         let is_ascii = token_text.as_str().is_ascii();
                         token_text.lowercase_in_place(is_ascii);
                     }
                 }
 
-                let token = Token {
-                    text: token_text.as_str(),
-                    position,
-                    byte_range: prev..bp,
-                    input_index,
-                };
-                callback(token)
+                token_text.into_current_token_text()
+            };
+
+            self.current_token = Some(CurrentToken {
+                text,
+                position,
+                byte_range: previous_breakpoint..breakpoint,
+                input_index: self.current_input_index,
             });
+            return true;
         }
     }
+
+    /// Returns the current token.
+    ///
+    /// Panics if the stream has not advanced to a token or is exhausted.
+    #[inline(always)]
+    pub fn token(&self) -> Token<'_> {
+        let current = self.current_token.as_ref().expect("no current token");
+        let text = match current.text {
+            CurrentTokenText::Input(text) => text,
+            CurrentTokenText::Buffer => self.buffer.a.as_str(),
+        };
+        Token {
+            text,
+            position: current.position,
+            byte_range: current.byte_range.clone(),
+            input_index: current.input_index,
+        }
+    }
+
+    /// Advances and returns the next analyzed token.
+    #[inline(always)]
+    pub fn next_token(&mut self) -> Option<Token<'_>> {
+        if self.advance() {
+            Some(self.token())
+        } else {
+            None
+        }
+    }
+}
+
+struct CurrentToken<'input> {
+    text: CurrentTokenText<'input>,
+    position: usize,
+    byte_range: Range<usize>,
+    input_index: usize,
+}
+
+enum CurrentTokenText<'input> {
+    Input(&'input str),
+    Buffer,
 }
 
 #[non_exhaustive]
 pub struct Token<'a> {
     /// Normalized text of the token, either sliced from the input string or from the reused
-    /// buffer. Only valid for the duration of the callback invocation.
+    /// buffer. Valid for the callback invocation or until the token stream is advanced.
     pub text: &'a str,
 
     /// Position of the token in the sequence of tokens. If `analyze_inputs` is used,
@@ -287,7 +415,7 @@ enum InputRefOrBuffered<'input, 'buf> {
     Buffered(&'buf mut String),
 }
 
-impl InputRefOrBuffered<'_, '_> {
+impl<'input> InputRefOrBuffered<'input, '_> {
     fn as_str(&self) -> &str {
         match self {
             Self::InputRef { input, .. } => input,
@@ -431,6 +559,13 @@ impl InputRefOrBuffered<'_, '_> {
         }
     }
 
+    fn into_current_token_text(self) -> CurrentTokenText<'input> {
+        match self {
+            Self::InputRef { input, .. } => CurrentTokenText::Input(input),
+            Self::Buffered(_) => CurrentTokenText::Buffer,
+        }
+    }
+
     // Mutates self to transition from `InputRef` to `Buffered`. Caller is responsible
     // for populating `buffer_if_needed` with the appropriate contents before calling this.
     fn transition_to_buffered(&mut self) {
@@ -459,6 +594,7 @@ mod tests {
     use super::*;
 
     /// Owned copy of a `Token`'s fields, so tests can use named access.
+    #[derive(Debug, Eq, PartialEq)]
     struct Tok {
         text: String,
         position: usize,
@@ -487,6 +623,26 @@ mod tests {
         collect_inputs(opts, std::iter::once(input))
     }
 
+    fn collect_stream_inputs<'a>(
+        opts: AnalysisOptions,
+        inputs: impl Iterator<Item = &'a str>,
+    ) -> Vec<Tok> {
+        let mut buffer = ReusableBuffer::new();
+        let analyzer = Analyzer::new(opts);
+        let mut stream = analyzer.token_stream_inputs(inputs, &mut buffer);
+        let mut out = Vec::new();
+        while stream.advance() {
+            let token = stream.token();
+            out.push(Tok {
+                text: token.text.to_string(),
+                position: token.position,
+                byte_range: token.byte_range,
+                input_index: token.input_index,
+            });
+        }
+        out
+    }
+
     fn opts() -> AnalysisOptions {
         AnalysisOptions {
             tokenizer: TokenizerOptions::UAX29Word(Default::default()),
@@ -496,6 +652,69 @@ mod tests {
             stemming: None,
             ascii_folding: false,
         }
+    }
+
+    #[test]
+    fn token_stream_matches_callback_api() {
+        let inputs = ["The café runners", "ΣΟΦΟΣ and 中 👨\u{200D}👩"];
+        let base = opts();
+        let options = [
+            AnalysisOptions {
+                case_sensitive: true,
+                ..base
+            },
+            base,
+            AnalysisOptions {
+                maximum_token_length: Some(4),
+                ..base
+            },
+            AnalysisOptions {
+                stopword_removal: Some(StopwordRemoval::ForLanguage(
+                    LanguageWithStopwords::English,
+                )),
+                ..base
+            },
+            AnalysisOptions {
+                stemming: Some(StemmingLanguage::English),
+                ..base
+            },
+            AnalysisOptions {
+                maximum_token_length: Some(40),
+                stopword_removal: Some(StopwordRemoval::ForLanguage(
+                    LanguageWithStopwords::English,
+                )),
+                stemming: Some(StemmingLanguage::English),
+                ascii_folding: true,
+                ..base
+            },
+        ];
+
+        for options in options {
+            assert_eq!(
+                collect_inputs(options, inputs.into_iter()),
+                collect_stream_inputs(options, inputs.into_iter()),
+            );
+        }
+    }
+
+    #[test]
+    fn token_stream_pulls_inputs_lazily() {
+        let inputs_pulled = std::cell::Cell::new(0);
+        let inputs = ["first", "second"].into_iter().inspect(|_| {
+            inputs_pulled.set(inputs_pulled.get() + 1);
+        });
+        let analyzer = Analyzer::new(opts());
+        let mut buffer = ReusableBuffer::new();
+        let mut stream = analyzer.token_stream_inputs(inputs, &mut buffer);
+
+        assert_eq!(inputs_pulled.get(), 0);
+        assert!(stream.advance());
+        assert_eq!(stream.token().text, "first");
+        assert_eq!(inputs_pulled.get(), 1);
+        assert!(stream.advance());
+        assert_eq!(stream.token().text, "second");
+        assert_eq!(inputs_pulled.get(), 2);
+        assert!(!stream.advance());
     }
 
     #[test]

--- a/src/analyze/mod.rs
+++ b/src/analyze/mod.rs
@@ -83,9 +83,9 @@ pub enum StemmingLanguage {
     Turkish,
 }
 
-impl Into<rust_stemmers::Algorithm> for StemmingLanguage {
-    fn into(self) -> rust_stemmers::Algorithm {
-        match self {
+impl From<StemmingLanguage> for rust_stemmers::Algorithm {
+    fn from(language: StemmingLanguage) -> Self {
+        match language {
             StemmingLanguage::Arabic => rust_stemmers::Algorithm::Arabic,
             StemmingLanguage::Danish => rust_stemmers::Algorithm::Danish,
             StemmingLanguage::Dutch => rust_stemmers::Algorithm::Dutch,
@@ -137,6 +137,12 @@ impl ReusableBuffer {
     }
 }
 
+impl Default for ReusableBuffer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 #[derive(Clone, Copy)]
 pub struct Analyzer {
     options: AnalysisOptions,
@@ -151,9 +157,9 @@ impl Analyzer {
     /// Analyzes a single input string, invoking the callback for each token.
     /// Returning false from the callback will stop analysis early.
     #[inline(always)]
-    pub fn analyze<'a>(
+    pub fn analyze(
         &self,
-        input: &'a str,
+        input: &str,
         buffer: &mut ReusableBuffer,
         mut callback: impl FnMut(Token<'_>) -> bool,
     ) {
@@ -168,9 +174,9 @@ impl Analyzer {
     /// Analyzes a sequence of input strings, invoking the callback for each token.
     /// Returning false from the callback will stop analysis early.
     #[inline(always)]
-    pub fn analyze_inputs<'a>(
+    pub fn analyze_inputs<'input>(
         &self,
-        inputs: impl Iterator<Item = &'a str>,
+        inputs: impl IntoIterator<Item = &'input str>,
         buffer: &mut ReusableBuffer,
         mut callback: impl FnMut(Token<'_>) -> bool,
     ) {
@@ -194,13 +200,13 @@ impl Analyzer {
 
     /// Lazily analyzes a sequence of input strings.
     #[inline(always)]
-    pub fn token_stream_inputs<'input, 'buffer, I>(
+    pub fn token_stream_inputs<'input, 'buffer, Inputs>(
         &self,
-        inputs: I,
+        inputs: Inputs,
         buffer: &'buffer mut ReusableBuffer,
-    ) -> TokenStream<'input, 'buffer, I>
+    ) -> TokenStream<'input, 'buffer, Inputs::IntoIter>
     where
-        I: Iterator<Item = &'input str>,
+        Inputs: IntoIterator<Item = &'input str>,
     {
         let TokenizerOptions::UAX29Word(tokenizer_options) = self.options.tokenizer;
 
@@ -212,14 +218,11 @@ impl Analyzer {
         TokenStream {
             options: self.options,
             tokenizer_options,
-            inputs: inputs.enumerate(),
+            inputs: inputs.into_iter().enumerate(),
             buffer,
             stemmer,
             next_position: 0,
-            current_input: None,
-            current_input_index: 0,
-            breakpoints: None,
-            previous_breakpoint: None,
+            input: None,
             current_token: None,
         }
     }
@@ -227,10 +230,9 @@ impl Analyzer {
 
 /// A lazy stream of analyzed tokens.
 ///
-/// Call [`advance`](Self::advance), then inspect the current token with
-/// [`token`](Self::token). The returned token is valid until the next mutable
-/// operation on the stream. This is a lending stream rather than an
-/// [`Iterator`] because token text may borrow from the reusable buffer.
+/// This is a lending stream rather than an [`Iterator`] because token text may
+/// borrow from the reusable buffer.
+#[must_use = "token streams are lazy and do nothing unless consumed"]
 pub struct TokenStream<'input, 'buffer, I>
 where
     I: Iterator<Item = &'input str>,
@@ -241,10 +243,7 @@ where
     buffer: &'buffer mut ReusableBuffer,
     stemmer: Option<rust_stemmers::Stemmer>,
     next_position: usize,
-    current_input: Option<&'input str>,
-    current_input_index: usize,
-    breakpoints: Option<uax29::word::Breakpoints<'input>>,
-    previous_breakpoint: Option<usize>,
+    input: Option<InputStream<'input>>,
     current_token: Option<CurrentToken<'input>>,
 }
 
@@ -252,28 +251,20 @@ impl<'input, I> TokenStream<'input, '_, I>
 where
     I: Iterator<Item = &'input str>,
 {
-    /// Advances to the next analyzed token.
     #[inline(always)]
-    pub fn advance(&mut self) -> bool {
+    fn advance(&mut self) -> bool {
         self.current_token = None;
 
         loop {
-            if self.breakpoints.is_none() {
+            if self.input.is_none() {
                 let Some((input_index, input)) = self.inputs.next() else {
                     return false;
                 };
-                self.current_input = Some(input);
-                self.current_input_index = input_index;
-                self.breakpoints = Some(uax29::word::breakpoints(input, self.tokenizer_options));
-                self.previous_breakpoint = None;
+                self.input = Some(InputStream::new(input_index, input, self.tokenizer_options));
             }
 
-            let Some((breakpoint, properties)) = self.breakpoints.as_mut().unwrap().next() else {
-                self.breakpoints = None;
-                self.current_input = None;
-                continue;
-            };
-            let Some(previous_breakpoint) = self.previous_breakpoint.replace(breakpoint) else {
+            let Some((byte_range, properties)) = self.input.as_mut().unwrap().next_span() else {
+                self.input = None;
                 continue;
             };
             if !properties.is_word_like() {
@@ -285,7 +276,9 @@ where
             let position = self.next_position;
             self.next_position += 1;
 
-            let input = self.current_input.unwrap();
+            let input = self.input.as_ref().unwrap();
+            let input_index = input.index;
+            let input = input.text;
             let input_as_bytes = input.as_bytes();
             let text = {
                 let ReusableBuffer {
@@ -298,9 +291,7 @@ where
                 buffer_a.clear();
                 let mut token_text = InputRefOrBuffered::InputRef {
                     input: unsafe {
-                        std::str::from_utf8_unchecked(
-                            &input_as_bytes[previous_breakpoint..breakpoint],
-                        )
+                        std::str::from_utf8_unchecked(&input_as_bytes[byte_range.clone()])
                     },
                     buffer_if_needed: buffer_a,
                 };
@@ -339,18 +330,15 @@ where
             self.current_token = Some(CurrentToken {
                 text,
                 position,
-                byte_range: previous_breakpoint..breakpoint,
-                input_index: self.current_input_index,
+                byte_range,
+                input_index,
             });
             return true;
         }
     }
 
-    /// Returns the current token.
-    ///
-    /// Panics if the stream has not advanced to a token or is exhausted.
     #[inline(always)]
-    pub fn token(&self) -> Token<'_> {
+    fn token(&self) -> Token<'_> {
         let current = self.current_token.as_ref().expect("no current token");
         let text = match current.text {
             CurrentTokenText::Input(text) => text,
@@ -364,7 +352,9 @@ where
         }
     }
 
-    /// Advances and returns the next analyzed token.
+    /// Returns the next analyzed token.
+    ///
+    /// The token is valid until the next mutable operation on the stream.
     #[inline(always)]
     pub fn next_token(&mut self) -> Option<Token<'_>> {
         if self.advance() {
@@ -380,6 +370,35 @@ struct CurrentToken<'input> {
     position: usize,
     byte_range: Range<usize>,
     input_index: usize,
+}
+
+struct InputStream<'input> {
+    index: usize,
+    text: &'input str,
+    breakpoints: uax29::word::Breakpoints<'input>,
+    previous_breakpoint: Option<usize>,
+}
+
+impl<'input> InputStream<'input> {
+    fn new(index: usize, text: &'input str, options: uax29::word::Options) -> Self {
+        Self {
+            index,
+            text,
+            breakpoints: uax29::word::breakpoints(text, options),
+            previous_breakpoint: None,
+        }
+    }
+
+    #[inline(always)]
+    fn next_span(&mut self) -> Option<(Range<usize>, uax29::word::TokenProperties)> {
+        loop {
+            let (breakpoint, properties) = self.breakpoints.next()?;
+            let Some(previous) = self.previous_breakpoint.replace(breakpoint) else {
+                continue;
+            };
+            return Some((previous..breakpoint, properties));
+        }
+    }
 }
 
 enum CurrentTokenText<'input> {
@@ -586,9 +605,6 @@ impl<'input> InputRefOrBuffered<'input, '_> {
     }
 }
 
-// TODO this has extensive coverage in the turbopuffer repo, but not in the crate itself
-// move some of the test suite in here
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -602,20 +618,28 @@ mod tests {
         input_index: usize,
     }
 
+    impl Tok {
+        fn from_token(token: Token<'_>) -> Self {
+            Self {
+                text: token.text.to_string(),
+                position: token.position,
+                byte_range: token.byte_range,
+                input_index: token.input_index,
+            }
+        }
+    }
+
     fn collect_inputs<'a>(
         opts: AnalysisOptions,
-        inputs: impl Iterator<Item = &'a str>,
+        inputs: impl IntoIterator<Item = &'a str>,
     ) -> Vec<Tok> {
+        let mut buffer = ReusableBuffer::new();
+        let analyzer = Analyzer::new(opts);
+        let mut stream = analyzer.token_stream_inputs(inputs, &mut buffer);
         let mut out = Vec::new();
-        Analyzer::new(opts).analyze_inputs(inputs, &mut ReusableBuffer::new(), |t| {
-            out.push(Tok {
-                text: t.text.to_string(),
-                position: t.position,
-                byte_range: t.byte_range,
-                input_index: t.input_index,
-            });
-            true
-        });
+        while let Some(token) = stream.next_token() {
+            out.push(Tok::from_token(token));
+        }
         out
     }
 
@@ -623,23 +647,15 @@ mod tests {
         collect_inputs(opts, std::iter::once(input))
     }
 
-    fn collect_stream_inputs<'a>(
+    fn collect_callback_inputs<'a>(
         opts: AnalysisOptions,
-        inputs: impl Iterator<Item = &'a str>,
+        inputs: impl IntoIterator<Item = &'a str>,
     ) -> Vec<Tok> {
-        let mut buffer = ReusableBuffer::new();
-        let analyzer = Analyzer::new(opts);
-        let mut stream = analyzer.token_stream_inputs(inputs, &mut buffer);
         let mut out = Vec::new();
-        while stream.advance() {
-            let token = stream.token();
-            out.push(Tok {
-                text: token.text.to_string(),
-                position: token.position,
-                byte_range: token.byte_range,
-                input_index: token.input_index,
-            });
-        }
+        Analyzer::new(opts).analyze_inputs(inputs, &mut ReusableBuffer::new(), |token| {
+            out.push(Tok::from_token(token));
+            true
+        });
         out
     }
 
@@ -691,8 +707,8 @@ mod tests {
 
         for options in options {
             assert_eq!(
-                collect_inputs(options, inputs.into_iter()),
-                collect_stream_inputs(options, inputs.into_iter()),
+                collect_inputs(options, inputs),
+                collect_callback_inputs(options, inputs),
             );
         }
     }
@@ -708,13 +724,11 @@ mod tests {
         let mut stream = analyzer.token_stream_inputs(inputs, &mut buffer);
 
         assert_eq!(inputs_pulled.get(), 0);
-        assert!(stream.advance());
-        assert_eq!(stream.token().text, "first");
+        assert_eq!(stream.next_token().unwrap().text, "first");
         assert_eq!(inputs_pulled.get(), 1);
-        assert!(stream.advance());
-        assert_eq!(stream.token().text, "second");
+        assert_eq!(stream.next_token().unwrap().text, "second");
         assert_eq!(inputs_pulled.get(), 2);
-        assert!(!stream.advance());
+        assert!(stream.next_token().is_none());
     }
 
     #[test]

--- a/src/analyze/stemming_cache.rs
+++ b/src/analyze/stemming_cache.rs
@@ -74,7 +74,7 @@ impl<const N: usize> ShortToken<N> {
 
     pub fn new_from_str(s: &str) -> Option<Self> {
         let bytes = s.as_bytes();
-        if bytes.len() == 0 || bytes.len() > N {
+        if bytes.is_empty() || bytes.len() > N {
             return None;
         }
         let mut buffer = [0; N];

--- a/src/analyze/u17_to_lower.rs
+++ b/src/analyze/u17_to_lower.rs
@@ -71,9 +71,7 @@ unsafe fn reconstruct(plane: u16, low: u16) -> char {
 
 fn lookup(input: char, l1_lut: &L1Lut) -> Option<[char; 3]> {
     let (input_high, input_low) = deconstruct(input);
-    let Some(l2_lut) = l1_lut.l2_luts.get(input_high as usize) else {
-        return None;
-    };
+    let l2_lut = l1_lut.l2_luts.get(input_high as usize)?;
 
     let idx = l2_lut.singles.binary_search_by(|(range, _)| {
         use std::cmp::Ordering;

--- a/src/uax29/sentence/mod.rs
+++ b/src/uax29/sentence/mod.rs
@@ -63,10 +63,8 @@ pub fn tokenize(text: &str, _options: Options, mut on_breakpoint: impl FnMut(usi
     }
 
     // Deferred state at EOT — defer failed, confirm break
-    if state.is_deferred() {
-        if !on_breakpoint(deferred_break_pos.unwrap()) {
-            return;
-        }
+    if state.is_deferred() && !on_breakpoint(deferred_break_pos.unwrap()) {
+        return;
     }
 
     // SB2: Any	÷ eot (break at end of text)

--- a/src/uax29/sentence/properties.rs
+++ b/src/uax29/sentence/properties.rs
@@ -195,7 +195,7 @@ mod tests {
                     .join(", ");
                 println!("    {},", row_str);
             }
-            assert!(false);
+            panic!("ASCII sentence-break table is stale");
         }
     }
 }

--- a/src/uax29/word/mod.rs
+++ b/src/uax29/word/mod.rs
@@ -49,179 +49,201 @@ impl std::ops::BitOrAssign for TokenProperties {
     }
 }
 
+/// Lazily yields the UAX #29 word boundaries in `text` and the properties of
+/// the span ending at each boundary.
+#[inline]
+pub fn breakpoints(text: &str, _options: Options) -> Breakpoints<'_> {
+    Breakpoints {
+        text,
+        state: State::StartOfText,
+        deferred_break_pos: None,
+        pos: 0,
+        last_was_zwj: false,
+        token_props: TokenProperties::default(),
+        deferred_props: TokenProperties::default(),
+        finished: text.is_empty(),
+    }
+}
+
+pub struct Breakpoints<'a> {
+    text: &'a str,
+    state: State,
+    deferred_break_pos: Option<usize>,
+    pos: usize,
+    last_was_zwj: bool,
+    token_props: TokenProperties,
+    deferred_props: TokenProperties,
+    finished: bool,
+}
+
+impl Iterator for Breakpoints<'_> {
+    type Item = (usize, TokenProperties);
+
+    #[inline(always)]
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.finished {
+            return None;
+        }
+
+        let bytes = self.text.as_bytes();
+
+        // WB4 says: X (Extend | Format | ZWJ)*	→	X
+        // To avoid adding _many_ `_AfterZWJ` variant states, we'll cheat a little by keeping track
+        // of this condition with a bool. More specifically, we need to conditionally break based on
+        // whether the previous character was a ZWJ.
+        //
+        // Example:
+        // 'a 🛑' -> break (ALetter -> Other)
+        // 'a ZWJ 🛑' -> no break (WB4)
+        while self.pos < self.text.len() {
+            // Fast path for ASCII, e.g. skip DFA all together when possible.
+            // Roughly a ~2x speedup on English Wikipedia.
+            if matches!(
+                self.state,
+                State::ALetter | State::Numeric | State::ExtendNumLet | State::HLetter
+            ) {
+                let scan_start = self.pos;
+                let mut fast_acc: u8 = 0;
+                while self.pos < self.text.len() && bytes[self.pos] < 0x80 {
+                    let info = ASCII_BYTE_INFO[bytes[self.pos] as usize];
+                    if info & ASCII_WORD_CONTINUE == 0 {
+                        break;
+                    }
+                    fast_acc |= info;
+                    self.pos += 1;
+                }
+                if self.pos > scan_start {
+                    self.token_props.0 |= fast_acc & !ASCII_WORD_CONTINUE;
+                    let last = bytes[self.pos - 1]; // Safe because we're not in State::StartOfText.
+                    self.state = match last {
+                        b'0'..=b'9' => State::Numeric,
+                        b'_' => State::ExtendNumLet,
+                        _ => State::ALetter,
+                    };
+                    self.last_was_zwj = false;
+                    continue;
+                }
+            }
+
+            // Fast path for ASCII, e.g. avoid chars().next(), and lookup word property from table.
+            // `char_props` is this char's contribution to the enclosing token's properties; it's
+            // applied to `token_props` per-arm below, since `Action::Break` treats the breaking char
+            // as the first char of the *next* token (the contribution lands there, not in the token
+            // being emitted).
+            let b = bytes[self.pos];
+            let (c, prop, char_len, char_props) = if b < 0x80 {
+                (
+                    b as char,
+                    ASCII_WORD_BREAK_PROP[b as usize],
+                    1usize,
+                    TokenProperties(ASCII_BYTE_INFO[b as usize] & !ASCII_WORD_CONTINUE),
+                )
+            } else {
+                let c = self.text[self.pos..].chars().next().unwrap();
+                let prop = lookup_word_break_property_from_dictionary(c);
+                // Cheap path covers ALetter / HebrewLetter / Numeric. For everything else, fall back
+                // to the strict per-char check (ExtPict / Ideographic / Script / OtherNumber).
+                let mut char_props = TokenProperties::NON_ASCII;
+                char_props |= WORD_BREAK_CONTRIB[prop as usize];
+                if !char_props.is_word_like() && is_word_like_strict(c) {
+                    char_props |= TokenProperties::WORD_LIKE;
+                }
+                (c, prop, c.len_utf8(), char_props)
+            };
+
+            // Each iteration, we consult the transition table to determine the next state
+            // and whether to emit a breakpoint.
+            let Transition(next_state, action) = TABLE[self.state as usize][prop as usize];
+            match action {
+                Action::Break => {
+                    let boundary = self.pos;
+                    self.pos += char_len;
+                    if self.last_was_zwj {
+                        self.last_was_zwj = false;
+                        if WordBreakProperty::is_ext_pictographic(c) {
+                            // Transparent: char joins the in-progress token instead of breaking.
+                            self.token_props |= char_props;
+                            continue;
+                        }
+                    }
+                    self.last_was_zwj = prop == WordBreakProperty::ZWJ;
+                    self.state = next_state;
+                    let props = std::mem::take(&mut self.token_props);
+                    // Breaking char starts the next token; apply its contribution after the take.
+                    self.token_props |= char_props;
+                    return Some((boundary, props));
+                }
+                Action::NoBreak => {
+                    self.last_was_zwj = false;
+                    if next_state.is_deferred() {
+                        if self.deferred_break_pos.is_none() {
+                            self.deferred_break_pos = Some(self.pos);
+                        }
+                        self.deferred_props |= char_props;
+                    } else {
+                        if self.deferred_break_pos.take().is_some() {
+                            // Word resumed: deferred chars belong to the in-progress token.
+                            self.token_props |= std::mem::take(&mut self.deferred_props);
+                        }
+                        self.token_props |= char_props;
+                    }
+                    self.state = next_state;
+                    self.pos += char_len;
+                }
+                Action::DeferredBreak => {
+                    self.last_was_zwj = false;
+                    let boundary = self.deferred_break_pos.take().unwrap();
+                    self.state = next_state;
+                    // Notably, we don't advance `pos` here; the current char is re-examined on the
+                    // next iteration and will accumulate its props then — don't apply char_props here.
+                    let props = std::mem::take(&mut self.token_props);
+                    // Deferred chars start the next token.
+                    self.token_props |= std::mem::take(&mut self.deferred_props);
+                    return Some((boundary, props));
+                }
+                Action::Transparent => {
+                    self.last_was_zwj = prop == WordBreakProperty::ZWJ;
+                    // State doesn't change, but we still consume the character.
+                    self.pos += char_len;
+                    if self.deferred_break_pos.is_some() {
+                        self.deferred_props |= char_props;
+                    } else {
+                        self.token_props |= char_props;
+                    }
+                }
+            }
+        }
+
+        // Deferred state at EOT - defer failed
+        if self.state.is_deferred() {
+            let breakpoint = self.deferred_break_pos.take().unwrap();
+            self.state = State::StartOfText;
+            let props = std::mem::take(&mut self.token_props);
+            // Deferred chars become the trailing token.
+            self.token_props |= std::mem::take(&mut self.deferred_props);
+            return Some((breakpoint, props));
+        }
+
+        // WB2: Any ÷ eot — emit final segment
+        self.finished = true;
+        Some((self.text.len(), self.token_props))
+    }
+}
+
 /// A tokenizer that implements UAX #29 word boundary rules, using a deterministic finite automaton
 /// (DFA) to efficiently determine word boundaries in Unicode text. Includes a number of fast-paths
 /// for common cases, e.g. ASCII.
+#[inline(always)]
 pub fn tokenize(
     text: &str,
-    _options: Options,
+    options: Options,
     mut on_breakpoint: impl FnMut(usize, TokenProperties) -> bool,
 ) {
-    if text.is_empty() {
-        return;
-    }
-    let bytes = text.as_bytes();
-
-    let mut state = State::StartOfText;
-    let mut deferred_break_pos = None;
-    let mut pos = 0;
-
-    // WB4 says: X (Extend | Format | ZWJ)*	→	X
-    // To avoid adding _many_ `_AfterZWJ` variant states, we'll cheat a little by keeping track
-    // of this condition with a bool. More specifically, we need to conditionally break based on
-    // whether the previous character was a ZWJ.
-    //
-    // Example:
-    // 'a 🛑' -> break (ALetter -> Other)
-    // 'a ZWJ 🛑' -> no break (WB4)
-    let mut last_was_zwj = false;
-
-    // Maintain properties of the current token, which are reset on each break and can be used by the caller
-    // to more efficiently determine what type of token was just emitted, e.g. whether it's "word-like" or ascii.
-    let mut token_props = TokenProperties::default();
-
-    // Properties of chars consumed while in a deferred state. Held aside from `token_props`
-    // because we don't yet know which token they belong to: if the deferred state resolves
-    // via `DeferredBreak`, these chars start the *next* token (so their contribution must
-    // not leak into the in-progress one); if it resolves via `NoBreak` exiting deferred,
-    // they fold into the current token. Tracked by `deferred_break_pos.is_some()`.
-    let mut deferred_props = TokenProperties::default();
-
-    while pos < text.len() {
-        // Fast path for ASCII, e.g. skip DFA all together when possible.
-        // Roughly a ~2x speedup on English Wikipedia.
-        if matches!(
-            state,
-            State::ALetter | State::Numeric | State::ExtendNumLet | State::HLetter
-        ) {
-            let scan_start = pos;
-            let mut fast_acc: u8 = 0;
-            while pos < text.len() && bytes[pos] < 0x80 {
-                let info = ASCII_BYTE_INFO[bytes[pos] as usize];
-                if info & ASCII_WORD_CONTINUE == 0 {
-                    break;
-                }
-                fast_acc |= info;
-                pos += 1;
-            }
-            if pos > scan_start {
-                token_props.0 |= fast_acc & !ASCII_WORD_CONTINUE;
-                let last = bytes[pos - 1]; // Safe because we're not in State::StartOfText.
-                state = match last {
-                    b'0'..=b'9' => State::Numeric,
-                    b'_' => State::ExtendNumLet,
-                    _ => State::ALetter,
-                };
-                last_was_zwj = false;
-                continue;
-            }
-        }
-
-        // Fast path for ASCII, e.g. avoid chars().next(), and lookup word property from table.
-        // `char_props` is this char's contribution to the enclosing token's properties; it's
-        // applied to `token_props` per-arm below, since `Action::Break` treats the breaking char
-        // as the first char of the *next* token (the contribution lands there, not in the token
-        // being emitted).
-        let b = bytes[pos];
-        let (c, prop, char_len, char_props) = if b < 0x80 {
-            (
-                b as char,
-                ASCII_WORD_BREAK_PROP[b as usize],
-                1usize,
-                TokenProperties(ASCII_BYTE_INFO[b as usize] & !ASCII_WORD_CONTINUE),
-            )
-        } else {
-            let c = text[pos..].chars().next().unwrap();
-            let prop = lookup_word_break_property_from_dictionary(c);
-            // Cheap path covers ALetter / HebrewLetter / Numeric. For everything else, fall back
-            // to the strict per-char check (ExtPict / Ideographic / Script / OtherNumber).
-            let mut char_props = TokenProperties::NON_ASCII;
-            char_props |= WORD_BREAK_CONTRIB[prop as usize];
-            if !char_props.is_word_like() && is_word_like_strict(c) {
-                char_props |= TokenProperties::WORD_LIKE;
-            }
-            (c, prop, c.len_utf8(), char_props)
-        };
-
-        // Each iteration, we consult the transition table to determine the next state
-        // and whether to emit a breakpoint.
-        let Transition(next_state, action) = TABLE[state as usize][prop as usize];
-        match action {
-            Action::Break => {
-                let boundary = pos;
-                pos += char_len;
-                if last_was_zwj {
-                    last_was_zwj = false;
-                    if WordBreakProperty::is_ext_pictographic(c) {
-                        // Transparent: char joins the in-progress token instead of breaking.
-                        token_props |= char_props;
-                        continue;
-                    }
-                }
-                last_was_zwj = prop == WordBreakProperty::ZWJ;
-                state = next_state;
-                if !on_breakpoint(boundary, std::mem::take(&mut token_props)) {
-                    return;
-                }
-                // Breaking char starts the next token; apply its contribution after the take.
-                token_props |= char_props;
-                continue;
-            }
-            Action::NoBreak => {
-                last_was_zwj = false;
-                if next_state.is_deferred() {
-                    if deferred_break_pos.is_none() {
-                        deferred_break_pos = Some(pos);
-                    }
-                    deferred_props |= char_props;
-                } else {
-                    if deferred_break_pos.take().is_some() {
-                        // Word resumed: deferred chars belong to the in-progress token.
-                        token_props |= std::mem::take(&mut deferred_props);
-                    }
-                    token_props |= char_props;
-                }
-                state = next_state;
-                pos += char_len;
-            }
-            Action::DeferredBreak => {
-                last_was_zwj = false;
-                let boundary = deferred_break_pos.take().unwrap();
-                state = next_state;
-                // Notably, we don't advance `pos` here; the current char is re-examined on the
-                // next iteration and will accumulate its props then — don't apply char_props here.
-                if !on_breakpoint(boundary, std::mem::take(&mut token_props)) {
-                    return;
-                }
-                // Deferred chars start the next token.
-                token_props |= std::mem::take(&mut deferred_props);
-                continue;
-            }
-            Action::Transparent => {
-                last_was_zwj = prop == WordBreakProperty::ZWJ;
-                // State doesn't change, but we still consume the character.
-                pos += char_len;
-                if deferred_break_pos.is_some() {
-                    deferred_props |= char_props;
-                } else {
-                    token_props |= char_props;
-                }
-            }
+    for (breakpoint, properties) in breakpoints(text, options) {
+        if !on_breakpoint(breakpoint, properties) {
+            break;
         }
     }
-
-    // Deferred state at EOT - defer failed
-    if state.is_deferred() {
-        let breakpoint = deferred_break_pos.take().unwrap();
-        if !on_breakpoint(breakpoint, std::mem::take(&mut token_props)) {
-            return;
-        }
-        // Deferred chars become the trailing token.
-        token_props |= std::mem::take(&mut deferred_props);
-    }
-
-    // WB2: Any ÷ eot — emit final segment
-    _ = on_breakpoint(text.len(), token_props);
 }
 
 /// Cheap-path `TokenProperties` contribution for each `WordBreakProperty` value. Covers the
@@ -262,7 +284,7 @@ const ASCII_BYTE_INFO: [u8; 128] = {
 
 #[cfg(test)]
 mod tests {
-    use super::{Options, tokenize};
+    use super::{Options, breakpoints, tokenize};
     use crate::uax29::test_helpers::test_against_uax29_break_tests;
 
     #[test]
@@ -392,6 +414,32 @@ mod tests {
 
         // Circled letters
         assert_breaks("\u{200d}Ⓜ", vec![0, 6]);
+    }
+
+    #[test]
+    fn breakpoints_iterator_matches_callback() {
+        for input in [
+            "",
+            "hello",
+            "can' hi",
+            "אקספרס\u{05F4} מהיום",
+            "👨\u{200D}👩",
+        ] {
+            let from_iterator = breakpoints(input, Options::default()).collect::<Vec<_>>();
+            let mut from_callback = Vec::new();
+            tokenize(input, Options::default(), |breakpoint, properties| {
+                from_callback.push((breakpoint, properties));
+                true
+            });
+            assert_eq!(from_iterator, from_callback, "input: {input:?}");
+        }
+    }
+
+    #[test]
+    fn breakpoints_iterator_is_lazy() {
+        let mut breakpoints = breakpoints("one two three", Options::default());
+        assert_eq!(breakpoints.next().map(|(position, _)| position), Some(0));
+        assert_eq!(breakpoints.next().map(|(position, _)| position), Some(3));
     }
 
     #[test]

--- a/src/uax29/word/mod.rs
+++ b/src/uax29/word/mod.rs
@@ -61,10 +61,16 @@ pub fn breakpoints(text: &str, _options: Options) -> Breakpoints<'_> {
         last_was_zwj: false,
         token_props: TokenProperties::default(),
         deferred_props: TokenProperties::default(),
-        finished: text.is_empty(),
+        end: if text.is_empty() {
+            EndState::Finished
+        } else {
+            EndState::Running
+        },
     }
 }
 
+/// Lazy UAX #29 word boundaries and their span properties.
+#[must_use = "word boundaries are produced only when the iterator is consumed"]
 pub struct Breakpoints<'a> {
     text: &'a str,
     state: State,
@@ -73,7 +79,14 @@ pub struct Breakpoints<'a> {
     last_was_zwj: bool,
     token_props: TokenProperties,
     deferred_props: TokenProperties,
-    finished: bool,
+    end: EndState,
+}
+
+#[derive(Clone, Copy, Eq, PartialEq)]
+enum EndState {
+    Running,
+    FinalBreakpointPending,
+    Finished,
 }
 
 impl Iterator for Breakpoints<'_> {
@@ -81,7 +94,7 @@ impl Iterator for Breakpoints<'_> {
 
     #[inline(always)]
     fn next(&mut self) -> Option<Self::Item> {
-        if self.finished {
+        if self.end == EndState::Finished {
             return None;
         }
 
@@ -215,9 +228,9 @@ impl Iterator for Breakpoints<'_> {
         }
 
         // Deferred state at EOT - defer failed
-        if self.state.is_deferred() {
+        if self.state.is_deferred() && self.end == EndState::Running {
             let breakpoint = self.deferred_break_pos.take().unwrap();
-            self.state = State::StartOfText;
+            self.end = EndState::FinalBreakpointPending;
             let props = std::mem::take(&mut self.token_props);
             // Deferred chars become the trailing token.
             self.token_props |= std::mem::take(&mut self.deferred_props);
@@ -225,10 +238,12 @@ impl Iterator for Breakpoints<'_> {
         }
 
         // WB2: Any ÷ eot — emit final segment
-        self.finished = true;
+        self.end = EndState::Finished;
         Some((self.text.len(), self.token_props))
     }
 }
+
+impl std::iter::FusedIterator for Breakpoints<'_> {}
 
 /// A tokenizer that implements UAX #29 word boundary rules, using a deterministic finite automaton
 /// (DFA) to efficiently determine word boundaries in Unicode text. Includes a number of fast-paths
@@ -290,11 +305,8 @@ mod tests {
     #[test]
     fn test_word_break_against_uax29_tests() {
         let (passed, failed) =
-            test_against_uax29_break_tests("testdata/WordBreakTest.txt", |s, breakpoints| {
-                tokenize(s, Options::default(), |bp, _props| {
-                    breakpoints.push(bp);
-                    true
-                });
+            test_against_uax29_break_tests("testdata/WordBreakTest.txt", |s, actual| {
+                actual.extend(breakpoints(s, Options::default()).map(|(position, _)| position));
             });
         assert_eq!(
             (1944, 0),

--- a/src/uax29/word/properties.rs
+++ b/src/uax29/word/properties.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::upper_case_acronyms)]
+
 use tpuf_icu_properties_211::{
     CodePointMapData, CodePointMapDataBorrowed, CodePointSetData, CodePointSetDataBorrowed,
     props::{ExtendedPictographic, GeneralCategory, Ideographic, Script, WordBreak},
@@ -289,7 +291,7 @@ mod tests {
                     .join(", ");
                 println!("    {},", row_str);
             }
-            assert!(false);
+            panic!("ASCII word-break table is stale");
         }
     }
 }

--- a/tests/analysis_golden.rs
+++ b/tests/analysis_golden.rs
@@ -1,0 +1,267 @@
+use std::{
+    collections::hash_map::DefaultHasher,
+    hash::{Hash, Hasher},
+};
+
+use alyze::{
+    analyze::{
+        AnalysisOptions, Analyzer, LanguageWithStopwords, ReusableBuffer, StemmingLanguage,
+        StopwordRemoval, Token, TokenizerOptions,
+    },
+    uax29,
+};
+
+#[path = "../dev/wikipedia.rs"]
+mod wikipedia_data;
+use wikipedia_data::{CHUNK_BYTES, load_n_bytes};
+
+fn hash_token(token: Token<'_>, hasher: &mut impl Hasher) {
+    token.text.hash(hasher);
+    token.position.hash(hasher);
+    token.byte_range.hash(hasher);
+    token.input_index.hash(hasher);
+}
+
+fn base_options() -> AnalysisOptions {
+    AnalysisOptions {
+        tokenizer: TokenizerOptions::UAX29Word(uax29::word::Options::default()),
+        maximum_token_length: None,
+        case_sensitive: false,
+        stopword_removal: None,
+        stemming: None,
+        ascii_folding: false,
+    }
+}
+
+fn analysis_options() -> Vec<(&'static str, AnalysisOptions)> {
+    let base = base_options();
+    let mut options = vec![
+        (
+            "case-sensitive",
+            AnalysisOptions {
+                case_sensitive: true,
+                ..base
+            },
+        ),
+        ("lowercase", base),
+        (
+            "maximum-length-1",
+            AnalysisOptions {
+                maximum_token_length: Some(1),
+                ..base
+            },
+        ),
+        (
+            "maximum-length-4",
+            AnalysisOptions {
+                maximum_token_length: Some(4),
+                ..base
+            },
+        ),
+        (
+            "ascii-folding",
+            AnalysisOptions {
+                ascii_folding: true,
+                ..base
+            },
+        ),
+        (
+            "full-english",
+            AnalysisOptions {
+                maximum_token_length: Some(40),
+                stopword_removal: Some(StopwordRemoval::ForLanguage(
+                    LanguageWithStopwords::English,
+                )),
+                stemming: Some(StemmingLanguage::English),
+                ascii_folding: true,
+                ..base
+            },
+        ),
+    ];
+
+    for (name, language) in [
+        ("stopwords-danish", LanguageWithStopwords::Danish),
+        ("stopwords-dutch", LanguageWithStopwords::Dutch),
+        ("stopwords-english", LanguageWithStopwords::English),
+        ("stopwords-finnish", LanguageWithStopwords::Finnish),
+        ("stopwords-french", LanguageWithStopwords::French),
+        ("stopwords-german", LanguageWithStopwords::German),
+        ("stopwords-hungarian", LanguageWithStopwords::Hungarian),
+        ("stopwords-italian", LanguageWithStopwords::Italian),
+        ("stopwords-norwegian", LanguageWithStopwords::Norwegian),
+        ("stopwords-portuguese", LanguageWithStopwords::Portuguese),
+        ("stopwords-russian", LanguageWithStopwords::Russian),
+        ("stopwords-spanish", LanguageWithStopwords::Spanish),
+        ("stopwords-swedish", LanguageWithStopwords::Swedish),
+    ] {
+        options.push((
+            name,
+            AnalysisOptions {
+                stopword_removal: Some(StopwordRemoval::ForLanguage(language)),
+                ..base
+            },
+        ));
+    }
+
+    for (name, language) in [
+        ("stemming-arabic", StemmingLanguage::Arabic),
+        ("stemming-danish", StemmingLanguage::Danish),
+        ("stemming-dutch", StemmingLanguage::Dutch),
+        ("stemming-english", StemmingLanguage::English),
+        ("stemming-finnish", StemmingLanguage::Finnish),
+        ("stemming-french", StemmingLanguage::French),
+        ("stemming-german", StemmingLanguage::German),
+        ("stemming-greek", StemmingLanguage::Greek),
+        ("stemming-hungarian", StemmingLanguage::Hungarian),
+        ("stemming-italian", StemmingLanguage::Italian),
+        ("stemming-norwegian", StemmingLanguage::Norwegian),
+        ("stemming-portuguese", StemmingLanguage::Portuguese),
+        ("stemming-romanian", StemmingLanguage::Romanian),
+        ("stemming-russian", StemmingLanguage::Russian),
+        ("stemming-spanish", StemmingLanguage::Spanish),
+        ("stemming-swedish", StemmingLanguage::Swedish),
+        ("stemming-tamil", StemmingLanguage::Tamil),
+        ("stemming-turkish", StemmingLanguage::Turkish),
+    ] {
+        options.push((
+            name,
+            AnalysisOptions {
+                stemming: Some(language),
+                ..base
+            },
+        ));
+    }
+
+    options
+}
+
+fn benchmark_options() -> Vec<(&'static str, AnalysisOptions)> {
+    let base = base_options();
+    vec![
+        (
+            "case-sensitive",
+            AnalysisOptions {
+                case_sensitive: true,
+                ..base
+            },
+        ),
+        ("lowercase", base),
+        (
+            "stopwords",
+            AnalysisOptions {
+                stopword_removal: Some(StopwordRemoval::ForLanguage(
+                    LanguageWithStopwords::English,
+                )),
+                ..base
+            },
+        ),
+        (
+            "stemming",
+            AnalysisOptions {
+                stemming: Some(StemmingLanguage::English),
+                ..base
+            },
+        ),
+        (
+            "full-pipeline",
+            AnalysisOptions {
+                maximum_token_length: Some(40),
+                stopword_removal: Some(StopwordRemoval::ForLanguage(
+                    LanguageWithStopwords::English,
+                )),
+                stemming: Some(StemmingLanguage::English),
+                ascii_folding: true,
+                ..base
+            },
+        ),
+    ]
+}
+
+fn callback_digest(options: AnalysisOptions, inputs: &[String]) -> (usize, u64) {
+    let mut hasher = DefaultHasher::new();
+    let mut count = 0;
+    Analyzer::new(options).analyze_inputs(
+        inputs.iter().map(String::as_str),
+        &mut ReusableBuffer::new(),
+        |token| {
+            hash_token(token, &mut hasher);
+            count += 1;
+            true
+        },
+    );
+    (count, hasher.finish())
+}
+
+fn stream_digest(options: AnalysisOptions, inputs: &[String]) -> (usize, u64) {
+    let mut hasher = DefaultHasher::new();
+    let mut count = 0;
+    let mut buffer = ReusableBuffer::new();
+    let analyzer = Analyzer::new(options);
+    let mut stream = analyzer.token_stream_inputs(inputs.iter().map(String::as_str), &mut buffer);
+    while let Some(token) = stream.next_token() {
+        hash_token(token, &mut hasher);
+        count += 1;
+    }
+    (count, hasher.finish())
+}
+
+fn corpus_digest(inputs: &[String], options: Vec<(&'static str, AnalysisOptions)>) -> (usize, u64) {
+    let mut total_count = 0;
+    let mut total_hasher = DefaultHasher::new();
+    for (name, options) in options {
+        let (count, digest) = callback_digest(options, inputs);
+        assert_eq!(
+            stream_digest(options, inputs),
+            (count, digest),
+            "stream output differs from callback output for {name}"
+        );
+        total_count += count;
+        name.hash(&mut total_hasher);
+        count.hash(&mut total_hasher);
+        digest.hash(&mut total_hasher);
+    }
+    (total_count, total_hasher.finish())
+}
+
+fn conformance_inputs() -> Vec<String> {
+    let mut inputs = Vec::new();
+    for line in include_str!("../testdata/WordBreakTest.txt").lines() {
+        let source = line.split('#').next().unwrap().trim();
+        if source.is_empty() {
+            continue;
+        }
+        let text = source
+            .split_whitespace()
+            .filter(|part| *part != "÷" && *part != "×")
+            .map(|part| char::from_u32(u32::from_str_radix(part, 16).unwrap()).unwrap())
+            .collect();
+        inputs.push(text);
+    }
+    inputs.extend(
+        [
+            "",
+            "THE café runners' coöperation isn't naïve",
+            "العَرَبِيَّة واللغات كلمات",
+            "Dansk nederlands English suomalainen français Deutsch",
+            "Ελληνικά magyar italiano norsk português română русский",
+            "Español svenska தமிழ் Türkçe İstanbul Iİıi",
+            "中文 日本語 한국어 ไทย 👨\u{200d}👩\u{200d}👧\u{200d}👦",
+            "one.two 1,234.56 foo_bar can't 3:00 A\u{308}\u{300}",
+            "\0\r\n\u{ad}\u{2060}\u{200d}\u{1f1e6}\u{1f1e7}",
+        ]
+        .map(str::to_owned),
+    );
+    inputs
+}
+
+#[test]
+fn analysis_matches_golden() {
+    let actual = corpus_digest(&conformance_inputs(), analysis_options());
+    assert_eq!(actual, (62_198, 13_013_864_069_378_490_261));
+}
+
+#[test]
+fn wikipedia_analysis_matches_golden() {
+    let actual = corpus_digest(&load_n_bytes(CHUNK_BYTES), benchmark_options());
+    assert_eq!(actual, (46_721_103, 11_235_000_508_967_425_851));
+}

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -71,7 +71,7 @@ struct LanguageInfo {
 
 /// Analyze `text` and return the resulting tokens.
 ///
-/// `options` is a plain JS object matching [`Options`]. On an invalid
+/// `options` is a plain JS object matching `Options`. On an invalid
 /// configuration (e.g. stemming with case sensitivity, or an unsupported
 /// language) this throws an `Error` whose message matches what the turbopuffer
 /// API would return.


### PR DESCRIPTION
Shifts alyze to being lazy, e.g. allowing callers to pull next tokens rather than using a callback. This makes the ergonomics of working with alyze much nicer. We retain backwards compatible methods for callback users.

Additionally, this PR adds:
- An example of usage to the README
- A new "golden" test suite which asserts hashes match before/after
- And some smaller Clippy lint fixes

No behaviour / analysis changes expected as a result of this PR. Also, no noticeable performance impact.