### PR TITLE
test: cover untested Analyzer validation cases in bindings

### DIFF
--- a/node/__test__/features.test.mjs
+++ b/node/__test__/features.test.mjs
@@ -131,5 +131,8 @@ test('Analyzer case sensitivity', () => {
 test('Analyzer validation throws', () => {
   assert.throws(() => new Analyzer({ stemming: true, caseSensitive: true }))
   assert.throws(() => new Analyzer({ stemming: true, language: 'klingon' }))
+  assert.throws(() => new Analyzer({ removeStopwords: true, caseSensitive: true }))
+  assert.throws(() => new Analyzer({ removeStopwords: true, language: 'tamil' })) // tamil stems, but has no stopword list
   assert.throws(() => new Analyzer({ maxTokenLength: 0 }))
+  assert.throws(() => new Analyzer({ maxTokenLength: 256 }))
 })

--- a/python/tests/test_features.py
+++ b/python/tests/test_features.py
@@ -147,4 +147,10 @@ def test_analyzer_validation():
     with pytest.raises(ValueError):
         af.Analyzer(stemming=True, language="klingon")
     with pytest.raises(ValueError):
+        af.Analyzer(remove_stopwords=True, case_sensitive=True)
+    with pytest.raises(ValueError):
+        af.Analyzer(remove_stopwords=True, language="tamil")  # tamil stems, but has no stopword list
+    with pytest.raises(ValueError):
         af.Analyzer(max_token_length=0)
+    with pytest.raises(ValueError):
+        af.Analyzer(max_token_length=256)


### PR DESCRIPTION
some followup on #19 

### Why
The Analyzer validation tests only covers two stemming cases + `max_token_length=0`, but `build_options` has five.

### Add:
adds missing three tests to both the python and node suites
- stopword removal + case sensitivity
- stopword removal with a language that has no stopword list (for example: tamil stems, but has no stopwords)
- `max_token_length = 256` To clarify, the tests now bound 0 and 256 exclusive. 1 and 255 are valid.

Test only, no behavioral changes. Both suites pass locally
- pytest 15/15
- node --test 13/13

### Testing
**python:**
cd alyze/python
pip install maturin pytest 
maturin develop
pytest -v

to test the changes relevant to this PR:
pytest tests/test_features.py::test_analyzer_validation -v

**node:**
cd alyze/node
npm ci && npm run build:debug && npm test